### PR TITLE
Adding ability to log non-global metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/github/lazyscribe/lazyscribe/branch/main/graph/badge.svg?token=M5BHYS2SSU)](https://codecov.io/github/lazyscribe/lazyscribe) ![PyPI](https://img.shields.io/pypi/v/lazyscribe) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/lazyscribe)
+[![codecov](https://codecov.io/github/lazyscribe/lazyscribe/branch/main/graph/badge.svg?token=M5BHYS2SSU)](https://codecov.io/github/lazyscribe/lazyscribe) ![PyPI](https://img.shields.io/pypi/v/lazyscribe) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/lazyscribe) [![Documentation Status](https://readthedocs.org/projects/lazyscribe/badge/?version=latest)](https://lazyscribe.readthedocs.io/en/latest/?badge=latest)
 
 # Lightweight, lazy experiment logging
 
@@ -13,10 +13,10 @@ view of all executed experiments.
 # Installation
 
 ```console
-$ python -m pip install lazyscribe@git+https://github.com/lazyscribe/lazyscribe
+$ python -m pip install lazyscribe
 ```
 
-# Usage
+# Basic Usage
 
 The basic usage involves instantiating a ``Project`` and using the context manager to log
 an experiment:
@@ -30,23 +30,29 @@ with project.log(name="My experiment") as exp:
     exp.log_parameter("algorithm", "lightgbm")
 ```
 
-You've created an experiment! To view the experimental data, call ``to_dict``:
+You've created an experiment! You can view the experimental data by using ``list``:
 
 ```python
-project["my-experiment"].to_dict()
+from pprint import pprint
+
+pprint(list(project))
 ```
 
 ```json
-{"name": "My experiment",
- "author": "<AUTHOR>",
- "last_updated_by": "<AUTHOR>",
- "metrics": {"auroc": 0.5},
- "parameters": {"algorithm": "lightgbm"},
- "created_at": "<CREATED_AT>",
- "last_updated": "<LAST_UPDATED>",
- "dependencies": [],
- "short_slug": "my-experiment",
- "slug": "my-experiment-<CREATED_AT>"}
+[
+    {
+        "name": "My experiment",
+        "author": "<AUTHOR>",
+        "last_updated_by": "<AUTHOR>",
+        "metrics": {"auroc": 0.5},
+        "parameters": {"algorithm": "lightgbm"},
+        "created_at": "<CREATED_AT>",
+        "last_updated": "<LAST_UPDATED>",
+        "dependencies": [],
+        "short_slug": "my-experiment",
+        "slug": "my-experiment-<CREATED_AT>"
+    }
+]
 ```
 
 Once you've finished, save the project to ``project.json``:

--- a/docs/how-to/basic.rst
+++ b/docs/how-to/basic.rst
@@ -28,4 +28,4 @@ to the ``Project.experiments`` list.
     exp = Experiment(name="My experiment", project=project.fpath, author=project.author)
     exp.log_metric(...)
     exp.log_parameter(...)
-    project.experiments.append(exp)
+    project.append(exp)

--- a/docs/how-to/tests.rst
+++ b/docs/how-to/tests.rst
@@ -1,0 +1,28 @@
+Log non-global metrics
+======================
+
+Sometimes, it's helpful to log non-global metrics to an experimenent. To do so, create a
+:py:class:`lazyscribe.Test` using :py:meth:`lazyscribe.Experiment.log_test`:
+
+.. code-block:: python
+
+    from lazyscribe import Project
+
+    project = Project()
+
+    with project.log(name="My experiment") as exp:
+        with exp.log_test(name="My test", description="Demo test") as test:
+            test.log_metric("metric", value)
+
+The :py:meth:`Experiment.log_test` context handler creates a :py:class:`Test` object and
+logs it back to the experiment when the handler exits. If you want to avoid using the context
+handler, instantiate your own test and append it to the ``tests`` list:
+
+.. code-block:: python
+
+    from lazyscribe import Test
+
+    with project.log(name="My experiment") as exp:
+        test = Test(name="My test", description="Demo test")
+        test.log_metric("metric", value)
+        exp.tests.append(test)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Contents
     :caption: How-to...
 
     how-to/basic
+    how-to/tests
     how-to/artifact
     how-to/dependencies
     how-to/readonly

--- a/lazyscribe/__init__.py
+++ b/lazyscribe/__init__.py
@@ -6,5 +6,6 @@ from typing import List
 
 from .experiment import Experiment
 from .project import Project
+from .test import Test
 
-__all__: List[str] = ["Experiment", "Project"]
+__all__: List[str] = ["Experiment", "Project", "Test"]

--- a/lazyscribe/_meta.py
+++ b/lazyscribe/_meta.py
@@ -1,3 +1,3 @@
 """Version."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -142,8 +142,7 @@ class Experiment:
     def log_metric(self, name: str, value: Union[float, int]):
         """Log a metric to the experiment.
 
-        If the ``name`` exists in the ``metrics`` dictionary, the value will be
-        appended to a list.
+        This method will overwrite existing keys.
 
         Parameters
         ----------
@@ -153,12 +152,7 @@ class Experiment:
             Value of the metric.
         """
         self.last_updated = datetime.now()
-        if name in self.metrics:
-            if not isinstance(self.metrics[name], list):
-                self.metrics[name] = [self.metrics[name]]
-            self.metrics[name].append(value)
-        else:
-            self.metrics[name] = value
+        self.metrics[name] = value
 
     def log_parameter(self, name: str, value: Any):
         """Log a parameter to the experiment.

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -1,13 +1,16 @@
 """Experiment dataclass."""
 
+from contextlib import contextmanager
 from datetime import datetime
 import getpass
 import logging
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Iterator, List, Union
 
 from attrs import asdict, define, field, frozen, Factory
 from slugify import slugify
+
+from .test import Test
 
 LOG = logging.getLogger(__name__)
 
@@ -33,6 +36,9 @@ def serializer(inst, field, value):
         return value.isoformat(timespec="seconds")
     if field is not None and field.name == "dependencies":
         new = [f"{exp.project}|{exp.slug}" for exp in value.values()]
+        return new
+    if field is not None and field.name == "tests":
+        new = [asdict(test) for test in value]
         return new
 
     return value
@@ -79,6 +85,7 @@ class Experiment:
     dependencies: Dict = field(eq=False, factory=lambda: {})
     short_slug: str = field()
     slug: str = field()
+    tests: List = Factory(lambda: [])
 
     @dir.default
     def _dir_factory(self) -> Path:
@@ -167,6 +174,32 @@ class Experiment:
         """
         self.last_updated = datetime.now()
         self.parameters[name] = value
+
+    @contextmanager
+    def log_test(self, name: str, description: str = None) -> Iterator[Test]:
+        """Add a test to the experiment using a context handler.
+
+        A test is a specific location for non-global metrics.
+
+        Parameters
+        ----------
+        name : str
+            Name of the test.
+        description : str, optional (default None)
+            An optional description for the test.
+
+        Yields
+        ------
+        Test
+            The :py:class:`lazyscribe.test.Test` dataclass.
+        """
+        test = Test(name=name, description=description)
+        try:
+            yield test
+
+            self.tests.append(test)
+        except Exception as exc:
+            raise exc
 
     def to_dict(self) -> Dict:
         """Serialize the experiment to a dictionary.

--- a/lazyscribe/test.py
+++ b/lazyscribe/test.py
@@ -30,8 +30,7 @@ class Test:
     def log_metric(self, name: str, value: Union[float, int]):
         """Log a metric to the test.
 
-        If the ``name`` exists in the ``metrics`` dictionary, the value will be
-        appended to a list.
+        This method will overwrite existing keys.
 
         Parameters
         ----------
@@ -40,12 +39,7 @@ class Test:
         value : int or float
             Value of the metric.
         """
-        if name in self.metrics:
-            if not isinstance(self.metrics[name], list):
-                self.metrics[name] = [self.metrics[name]]
-            self.metrics[name].append(value)
-        else:
-            self.metrics[name] = value
+        self.metrics[name] = value
 
 
 @frozen

--- a/lazyscribe/test.py
+++ b/lazyscribe/test.py
@@ -1,0 +1,53 @@
+"""Sub-population tests."""
+
+from typing import Dict, Optional, Union
+
+from attrs import define, frozen, Factory
+
+
+@define
+class Test:
+    """Sub-population tests.
+
+    These objects should only be instantiated within an experiment. A test is associated with
+    some subset of the entire experiment. For example, a test could be used to evaluate the
+    performance of a model against a specific subpopulation.
+
+    Parameters
+    ----------
+    name : str
+        The name of the test.
+    description : str, optional (default None)
+        A description of the test.
+    metrics : dict, optional (default {})
+        A dictionary of metric values. Each metric value can be an individual value or a list.
+    """
+
+    name: str
+    description: Optional[str] = Factory(lambda: None)
+    metrics: Dict = Factory(lambda: {})
+
+    def log_metric(self, name: str, value: Union[float, int]):
+        """Log a metric to the test.
+
+        If the ``name`` exists in the ``metrics`` dictionary, the value will be
+        appended to a list.
+
+        Parameters
+        ----------
+        name : str
+            Name of the metric.
+        value : int or float
+            Value of the metric.
+        """
+        if name in self.metrics:
+            if not isinstance(self.metrics[name], list):
+                self.metrics[name] = [self.metrics[name]]
+            self.metrics[name].append(value)
+        else:
+            self.metrics[name] = value
+
+
+@frozen
+class ReadOnlyTest(Test):
+    """Immutable version of the test."""

--- a/tests/data/down-project.json
+++ b/tests/data/down-project.json
@@ -10,6 +10,7 @@
             "project.json|my-experiment-20220101093000"
         ],
         "short_slug": "my-downstream-experiment",
-        "slug": "my-downstream-experiment-20220115093000"
+        "slug": "my-downstream-experiment-20220115093000",
+        "tests": []
     }
 ]

--- a/tests/data/merge_append.json
+++ b/tests/data/merge_append.json
@@ -8,7 +8,16 @@
         "last_updated": "2022-01-01T09:30:00",
         "dependencies": [],
         "short_slug": "my-experiment",
-        "slug": "my-experiment-20220101093000"
+        "slug": "my-experiment-20220101093000",
+        "tests": [
+            {
+                "name": "My test",
+                "description": null,
+                "metrics": {
+                    "name-subpop": 0.3
+                }
+            }
+        ]
     },
     {
         "name": "My second experiment",
@@ -19,6 +28,7 @@
         "last_updated": "2022-01-01T10:30:00",
         "dependencies": [],
         "short_slug": "my-second-experiment",
-        "slug": "my-second-experiment-20220101103000"
+        "slug": "my-second-experiment-20220101103000",
+        "tests": []
     }
 ]

--- a/tests/data/merge_distinct.json
+++ b/tests/data/merge_distinct.json
@@ -8,6 +8,7 @@
         "last_updated": "2022-01-01T10:30:00",
         "dependencies": [],
         "short_slug": "my-second-experiment",
-        "slug": "my-second-experiment-20220101103000"
+        "slug": "my-second-experiment-20220101103000",
+        "tests": []
     }
 ]

--- a/tests/data/merge_update.json
+++ b/tests/data/merge_update.json
@@ -9,7 +9,16 @@
         "last_updated": "2022-01-10T09:30:00",
         "dependencies": [],
         "short_slug": "my-experiment",
-        "slug": "my-experiment-20220101093000"
+        "slug": "my-experiment-20220101093000",
+        "tests": [
+            {
+                "name": "My test",
+                "description": null,
+                "metrics": {
+                    "name-subpop": 0.3
+                }
+            }
+        ]
     },
     {
         "name": "My second experiment",
@@ -20,6 +29,7 @@
         "last_updated": "2022-01-01T10:30:00",
         "dependencies": [],
         "short_slug": "my-second-experiment",
-        "slug": "my-second-experiment-20220101103000"
+        "slug": "my-second-experiment-20220101103000",
+        "tests": []
     }
 ]

--- a/tests/data/project.json
+++ b/tests/data/project.json
@@ -8,6 +8,15 @@
         "last_updated": "2022-01-01T09:30:00",
         "dependencies": [],
         "short_slug": "my-experiment",
-        "slug": "my-experiment-20220101093000"
+        "slug": "my-experiment-20220101093000",
+        "tests": [
+            {
+                "name": "My test",
+                "description": null,
+                "metrics": {
+                    "name-subpop": 0.3
+                }
+            }
+        ]
     }
 ]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -26,12 +26,11 @@ def test_experiment_logging():
     exp = Experiment(name="My experiment", project=Path("project.json"))
     exp.log_metric("name", 0.5)
     exp.log_metric("name-cv", 0.4)
-    exp.log_metric("name-cv", 0.6)
     exp.log_parameter("features", ["col1", "col2"])
     with exp.log_test(name="My test") as test:
         test.log_metric("name-subpop", 0.3)
 
-    assert exp.metrics == {"name": 0.5, "name-cv": [0.4, 0.6]}
+    assert exp.metrics == {"name": 0.5, "name-cv": 0.4}
     assert exp.parameters == {"features": ["col1", "col2"]}
     assert exp.tests == [Test(name="My test", metrics={"name-subpop": 0.3})]
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -7,6 +7,7 @@ from attrs.exceptions import FrozenInstanceError
 import pytest
 
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
+from lazyscribe.test import Test
 
 
 def test_attrs_default():
@@ -27,9 +28,12 @@ def test_experiment_logging():
     exp.log_metric("name-cv", 0.4)
     exp.log_metric("name-cv", 0.6)
     exp.log_parameter("features", ["col1", "col2"])
+    with exp.log_test(name="My test") as test:
+        test.log_metric("name-subpop", 0.3)
 
     assert exp.metrics == {"name": 0.5, "name-cv": [0.4, 0.6]}
     assert exp.parameters == {"features": ["col1", "col2"]}
+    assert exp.tests == [Test(name="My test", metrics={"name-subpop": 0.3})]
 
 
 def test_experiment_serialization():
@@ -39,6 +43,8 @@ def test_experiment_serialization():
         name="My experiment", project=Path("project.json"), author="root"
     )
     exp.log_metric("name", 0.5)
+    with exp.log_test(name="My test") as test:
+        test.log_metric("name-subpop", 0.3)
 
     assert exp.to_dict() == {
         "name": "My experiment",
@@ -51,6 +57,13 @@ def test_experiment_serialization():
         "dependencies": [],
         "short_slug": "my-experiment",
         "slug": f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}",
+        "tests": [
+            {
+                "name": "My test",
+                "description": None,
+                "metrics": {"name-subpop": 0.3}
+            }
+        ]
     }
 
 
@@ -79,7 +92,8 @@ def test_experiment_serialization_dependencies():
             f"other-project.json|my-experiment-{today.strftime('%Y%m%d%H%M%S')}"
         ],
         "short_slug": "my-downstream-experiment",
-        "slug": f"my-downstream-experiment-{today.strftime('%Y%m%d%H%M%S')}"
+        "slug": f"my-downstream-experiment-{today.strftime('%Y%m%d%H%M%S')}",
+        "tests": []
     }
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from lazyscribe import Project
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
+from lazyscribe.test import ReadOnlyTest, Test
 import pytest
 
 CURR_DIR = Path(__file__).resolve().parent
@@ -32,6 +33,7 @@ def test_logging_experiment():
         "dependencies": [],
         "short_slug": "my-experiment",
         "slug": f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}",
+        "tests": []
     }
     assert project["my-experiment"] == project.experiments[0]
     assert project[f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}"] == project.experiments[0]
@@ -69,6 +71,8 @@ def test_save_project(tmpdir):
     project = Project(fpath=project_location, author="root")
     with project.log(name="My experiment") as exp:
         exp.log_metric("name", 0.5)
+        with exp.log_test("My test") as test:
+            test.log_metric("name-subpop", 0.3)
 
     project.save()
     assert project_location.is_file()
@@ -87,7 +91,10 @@ def test_save_project(tmpdir):
             "last_updated": today.strftime("%Y-%m-%dT%H:%M:%S"),
             "dependencies": [],
             "short_slug": "my-experiment",
-            "slug": f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}"
+            "slug": f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}",
+            "tests": [
+                {"name": "My test", "description": None, "metrics": {"name-subpop": 0.3}}
+            ]
         }
     ]
 
@@ -101,7 +108,8 @@ def test_load_project():
         author="root",
         metrics={"name": 0.5},
         created_at=datetime(2022, 1, 1, 9, 30, 0),
-        last_updated=datetime(2022, 1, 1, 9, 30, 0)
+        last_updated=datetime(2022, 1, 1, 9, 30, 0),
+        tests=[Test(name="My test", metrics={"name-subpop": 0.3})]
     )
 
     assert project.experiments == [expected]
@@ -136,7 +144,8 @@ def test_load_project_readonly():
         author="root",
         metrics={"name": 0.5},
         created_at=datetime(2022, 1, 1, 9, 30, 0),
-        last_updated=datetime(2022, 1, 1, 9, 30, 0)
+        last_updated=datetime(2022, 1, 1, 9, 30, 0),
+        tests=[ReadOnlyTest(name="My test", metrics={"name-subpop": 0.3})]
     )
 
     assert project.experiments == [expected]
@@ -183,6 +192,7 @@ def test_merge_append():
             metrics={"name": 0.5},
             created_at=datetime(2022, 1, 1, 9, 30, 0),
             last_updated=datetime(2022, 1, 1, 9, 30, 0),
+            tests=[ReadOnlyTest(name="My test", metrics={"name-subpop": 0.3})]
         ),
         ReadOnlyExperiment(
             name="My second experiment",
@@ -209,6 +219,7 @@ def test_merge_distinct():
             metrics={"name": 0.5},
             created_at=datetime(2022, 1, 1, 9, 30, 0),
             last_updated=datetime(2022, 1, 1, 9, 30, 0),
+            tests=[ReadOnlyTest(name="My test", metrics={"name-subpop": 0.3})]
         ),
         ReadOnlyExperiment(
             name="My second experiment",
@@ -237,6 +248,7 @@ def test_merge_update():
             parameters={"features": ["col1", "col2", "col3"]},
             created_at=datetime(2022, 1, 1, 9, 30, 0),
             last_updated=datetime(2022, 1, 10, 9, 30, 0),
+            tests=[ReadOnlyTest(name="My test", metrics={"name-subpop": 0.3})]
         ),
         ReadOnlyExperiment(
             name="My second experiment",


### PR DESCRIPTION
In this PR, I've added another context handler within the `Experiment` class. This interface should help users log non-global metrics. I've also adjusted the `log_metric` file to not create a list on repeated use for a name.