### PR TITLE
Experiment and test lists for easy conversion to pandas

### DIFF
--- a/docs/how-to/tabular.rst
+++ b/docs/how-to/tabular.rst
@@ -1,0 +1,31 @@
+Represent the project as a table
+================================
+
+To aid in visualization and comparison, ``lazyscribe`` has a built-in method
+:py:meth:`lazyscribe.Project.to_tabular` for generating a ``pandas``-ready format:
+
+.. code-block:: python
+
+    from lazyscribe import Project
+
+    project = Project(fpath=..., mode="r")
+
+    experiments, tests = project.to_tabular()
+
+The ``experiments`` entry in the tuple is a list of dictionaries, with each dictionary
+representing a single experiment in the project. It will contain metadata as well as each
+metric value and parameters that aren't dictionaries, tuples, or lists. The ``tests`` object
+refers to :doc:`non-global metrics <tests>`. Similarly, it will contain some experiment metadata
+along with the test-level metrics from the experiment.
+
+To use these lists, convert them to :py:class:`pandas.DataFrame` objects with multi-index column names:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    exp_df = pd.DataFrame(experiments)
+    exp_df.columns = pd.MultiIndex.from_tuples(exp_df.columns)
+
+    test_df = pd.DataFrame(tests)
+    test_df.columns = pd.MultiIndex.from_tuples(test_df.columns)

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -282,6 +282,11 @@ class Project:
                     **{
                         ("metrics", key): value for key, value in exp["metrics"].items()
                     },
+                    **{
+                        ("parameters", key): value
+                        for key, value in exp["parameters"].items()
+                        if not isinstance(value, (tuple, list, dict))
+                    },
                 }
             )
             for test in exp["tests"]:
@@ -289,6 +294,7 @@ class Project:
                     {
                         ("name", ""): exp["name"],
                         ("short_slug", ""): exp["short_slug"],
+                        ("slug", ""): exp["slug"],
                         ("test", ""): test["name"],
                         ("description", ""): test["description"],
                         **{

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ build =
 docs = 
     furo
     matplotlib
+    pandas
     pillow
     scikit-learn
     sphinx

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -259,3 +259,41 @@ def test_merge_update():
             last_updated=datetime(2022, 1, 1, 10, 30, 0)
         )
     ]
+
+def test_to_tabular():
+    """Test converting a project to a pandas-ready list."""
+    project = Project(fpath=DATA_DIR / "merge_update.json", mode="r")
+    experiments, tests = project.to_tabular()
+
+    assert experiments == [
+        {
+            ("name", ""): "My experiment",
+            ("author", ""): "root",
+            ("last_updated_by", ""): "friend",
+            ("metrics", "name"): 0.5,
+            ("created_at", ""): "2022-01-01T09:30:00",
+            ("last_updated", ""): "2022-01-10T09:30:00",
+            ("short_slug", ""): "my-experiment",
+            ("slug", ""): "my-experiment-20220101093000",
+        },
+        {
+            ("name", ""): "My second experiment",
+            ("author", ""): "root",
+            ("last_updated_by", ""): "root",
+            ("created_at", ""): "2022-01-01T10:30:00",
+            ("last_updated", ""): "2022-01-01T10:30:00",
+            ("short_slug", ""): "my-second-experiment",
+            ("slug", ""): "my-second-experiment-20220101103000"
+        }
+    ]
+
+    assert tests == [
+        {
+            ("name", ""): "My experiment",
+            ("short_slug", ""): "my-experiment",
+            ("slug", ""): "my-experiment-20220101093000",
+            ("test", ""): "My test",
+            ("description", ""): None,
+            ("metrics", "name-subpop"): 0.3
+        }
+    ]

--- a/tutorials/basic.py
+++ b/tutorials/basic.py
@@ -9,6 +9,7 @@ experiment.
 import json
 
 from lazyscribe import Project
+import pandas as pd
 from sklearn.datasets import make_classification
 from sklearn.svm import SVC
 
@@ -31,6 +32,15 @@ with project.log(name="Base performance") as exp:
 # Finally, let's print and view the experiment data.
 
 print(json.dumps(list(project), indent=4, sort_keys=True))
+
+# %%
+# You can also represent the project in a table:
+
+experiments, tests = project.to_tabular()
+
+df = pd.DataFrame(experiments)
+df.columns = pd.MultiIndex.from_tuples(df.columns)
+df.head()
 
 # %%
 # Then, you can call :py:meth:`lazyscribe.Project.save` to save the output JSON.


### PR DESCRIPTION
In this PR, I've added a ``to_tabular`` method to `Project` to help users create experiment and test-level dataframes:

```python
import pandas as pd

from lazyscribe import Project

project = Project(..., mode="r")

experiments, tests = project.to_tabular()

exp_df = pd.DataFrame(experiments)
exp_df.columns = pd.MultiIndex.from_tuples(exp_df.columns)
```