### PR TITLE
Fixing the content-type for the readme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ packages = ["lazyscribe"]
 
 [tool.setuptools.dynamic]
 version = {attr = "lazyscribe._meta.__version__"}
-readme = {file = ["README.md"]}
+readme = {file = ["README.md"], content-type = "text/markdown"}
 
 ##############################################################################
 # Tooling


### PR DESCRIPTION
Package build and upload failed for v0.3.2 because of an error with the description content type. I used [this section in the setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata) to update the dynamic metadata for the `readme` field with the right content type.