### PR TITLE
Trying a new readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,12 @@
 # Required
 version: 2
 
+# Set the build version of Python and other tools
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     configuration: docs/conf.py
@@ -14,8 +20,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-    version: 3.8
-    system_packages: true
     install:
         - requirements: requirements.txt
         - method: pip


### PR DESCRIPTION
Since we migrated to the `pyproject.toml`, we haven't been able to publish updated documentation to readthedocs. I'm trying this configuration based on their docs.