### PR TITLE
Fixing our readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,12 @@
 # Required
 version: 2
 
+# Set the build version of Python and other tools
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     configuration: docs/conf.py
@@ -14,8 +20,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-    version: 3.8
-    system_packages: true
     install:
         - requirements: requirements.txt
         - method: pip


### PR DESCRIPTION
This PR does not represent a new release. I am opening a PR to the `main` branch to ensure we have updated documentation on RTD.

Our GitHub workflow should not trigger a new version on PyPI since we have it set to trigger on new GitHub releases.