### PR TITLE
Add docs workflow to build and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "docs/build/html"
+          path: "docs/_build/html"
   deploy:
     # Only dpeloy if it's not a PR event. PR is build only to ensure docs build
     if: ${{ github.event_name != 'pull_request'}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Build and deploy docs to GitHub Pages
+
+on:
+  release:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt .[docs]
+        shell: bash
+      - name: Sphinx build
+        run: make docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "docs/build/html"
+  deploy:
+    # Only dpeloy if it's not a PR event. PR is build only to ensure docs build
+    if: ${{ github.event_name != 'pull_request'}}
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Title. Build and deploy are separate jobs as recommended by GitHub. Will build docs on every PR, but only deploy on `release: created` or manually with `workflow_dispatch`.

To enable publishing GitHub Pages directly from an action, a repository admin will have to enable that setting in the repository settings. We _may_ have to merge to main for the initial build for `workflow_dispatch` trigger.