### PR TITLE
Modifying the `Project.to_tabular` output for test-level data and adding error handling for `JoblibArtifact.construct`

### DIFF
--- a/docs/sg_execution_times.rst
+++ b/docs/sg_execution_times.rst
@@ -1,0 +1,40 @@
+
+:orphan:
+
+.. _sphx_glr_sg_execution_times:
+
+
+Computation times
+=================
+**00:00.751** total execution time for 2 files **from all galleries**:
+
+.. container::
+
+  .. raw:: html
+
+    <style scoped>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    </style>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" class="init">
+    $(document).ready( function () {
+        $('table.sg-datatable').DataTable({order: [[1, 'desc']]});
+    } );
+    </script>
+
+  .. list-table::
+   :header-rows: 1
+   :class: table table-striped sg-datatable
+
+   * - Example
+     - Time
+     - Mem (MB)
+   * - :ref:`sphx_glr_tutorials_basic.py` (``../tutorials/basic.py``)
+     - 00:00.502
+     - 0.0
+   * - :ref:`sphx_glr_tutorials_prefect.py` (``../tutorials/prefect.py``)
+     - 00:00.250
+     - 0.0

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -82,7 +82,13 @@ class JoblibArtifact(Artifact):
                 raise ValueError(
                     "If no ``package`` is specified, you must supply a ``value``."
                 )
-            package = value.__module__.split(".")[0]
+            try:
+                package = value.__module__.split(".")[0]
+            except AttributeError as err:
+                raise AttributeError(
+                    "Unable to identify the package based on the supplied ``value``. "
+                    "Please provide an argument for ``package``."
+                ) from err
 
         try:
             distribution = packages_distributions()[package][0]

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -332,20 +332,20 @@ class Project:
             A ``tests`` level list. Each entry will represent a test, with the
             following keys:
 
-            +--------------------------+-------------------------------+
-            | Field                    | Description                   |
-            |                          |                               |
-            +==========================+===============================+
-            | ``("name",)``            | Name of the experiment        |
-            +--------------------------+-------------------------------+
-            | ``("short_slug",)``      | Short slug for the experiment |
-            +--------------------------+-------------------------------+
-            | ``("slug",)``            | Full slug for the experiment  |
-            +--------------------------+-------------------------------+
-            | ``("test",)``            | Test name                     |
-            +--------------------------+-------------------------------+
-            | ``("description",)``     | Test description              |
-            +--------------------------+-------------------------------+
+            +-------------------------------------+-------------------------------+
+            | Field                               | Description                   |
+            |                                     |                               |
+            +=====================================+===============================+
+            | ``("experiment_name",)``            | Name of the experiment        |
+            +-------------------------------------+-------------------------------+
+            | ``("experiment_short_slug",)``      | Short slug for the experiment |
+            +-------------------------------------+-------------------------------+
+            | ``("experiment_slug",)``            | Full slug for the experiment  |
+            +-------------------------------------+-------------------------------+
+            | ``("test",)``                       | Test name                     |
+            +-------------------------------------+-------------------------------+
+            | ``("description",)``                | Test description              |
+            +-------------------------------------+-------------------------------+
 
             as well as one key per metric in the ``metrics`` dictionary
             (with the format ``("metrics", <metric_name>)``) for each test.
@@ -376,9 +376,9 @@ class Project:
             for test in exp["tests"]:
                 test_output.append(
                     {
-                        ("name", ""): exp["name"],
-                        ("short_slug", ""): exp["short_slug"],
-                        ("slug", ""): exp["slug"],
+                        ("experiment_name", ""): exp["name"],
+                        ("experiment_short_slug", ""): exp["short_slug"],
+                        ("experiment_slug", ""): exp["slug"],
                         ("test", ""): test["name"],
                         ("description", ""): test["description"],
                         **{

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -71,6 +71,27 @@ def test_joblib_handler(tmp_path):
     ) == handler
 
 
+def test_joblib_handler_error_no_inputs():
+    """Test that the joblib handler raises an error when no value or package is provided."""
+    with pytest.raises(ValueError):
+        _ = JoblibArtifact.construct(name="My artifact")
+
+
+def test_joblib_handler_invalid_package():
+    """Test that the joblib handler raises an error when an invalid package is provided."""
+    with pytest.raises(ValueError):
+        _ = JoblibArtifact.construct(name="My artifact", package="my_invalid_package")
+
+
+def test_joblib_handler_raise_attribute_error():
+    """Test that the joblib handler raises an error for objects where the package can't be determined."""
+    numpy = pytest.importorskip("numpy")
+
+    myarr = numpy.array([])
+    with pytest.raises(AttributeError):
+        JoblibArtifact.construct(name="My array", value=myarr)
+
+
 def test_get_handler():
     """Test retrieving a handler."""
     handler = _get_handler("joblib")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -469,9 +469,9 @@ def test_to_tabular():
 
     assert tests == [
         {
-            ("name", ""): "My experiment",
-            ("short_slug", ""): "my-experiment",
-            ("slug", ""): "my-experiment-20220101093000",
+            ("experiment_name", ""): "My experiment",
+            ("experiment_short_slug", ""): "my-experiment",
+            ("experiment_slug", ""): "my-experiment-20220101093000",
             ("test", ""): "My test",
             ("description", ""): None,
             ("metrics", "name-subpop"): 0.3,


### PR DESCRIPTION
## Description

#28

In this PR, I have modified the test-level tabular output from `Project.to_tabular` so the experiment information is explicitly prefixed. I have also added error handling for the `JoblibArtifact`. @kuraga pointed out that some _very_ common objects (e.g. `numpy.array`) do not have the `__module__` attribute. I'm not sure how to get around that for the information we need, so I added error handling. Users can get around the error by specifying a `package` argument to the constructor.