### PR TITLE
docs/how-to: Make `Project()`'s arguments explicit

### DIFF
--- a/docs/how-to/artifact.rst
+++ b/docs/how-to/artifact.rst
@@ -14,7 +14,7 @@ to a unique folder based on experiment slug:
 
     from lazyscribe import Project
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
     with project.log("My experiment") as exp:
         exp.path
 
@@ -35,7 +35,7 @@ Serialization is delegated to a subclass of :py:class:`lazyscribe.artifacts.Arti
     from lazyscribe import Project
     from sklearn.svm import SVC
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
     with project.log("My experiment") as exp:
         X, y = ...
         model = SVC()

--- a/docs/how-to/basic.rst
+++ b/docs/how-to/basic.rst
@@ -7,7 +7,7 @@ To create your first project, instantiate the :py:class:`lazyscribe.Project` cla
 
     from lazyscribe import Project
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
 
 Then, use the context manager to create an experiment and log it back to the project.
 

--- a/docs/how-to/filter.rst
+++ b/docs/how-to/filter.rst
@@ -8,7 +8,7 @@ filter experiments. First, create a :py:class:`lazyscribe.Project`.
 
     from lazyscribe import Project
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
 
 Then, let's log a couple of experiments.
 

--- a/docs/how-to/tag.rst
+++ b/docs/how-to/tag.rst
@@ -8,7 +8,7 @@ let's create a :py:class:`lazyscribe.Project`.
 
     from lazyscribe import Project
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
 
 Then, while logging an experiment, we can add our tag using :py:meth:`lazyscribe.Experiment.tag`:
 

--- a/docs/how-to/tests.rst
+++ b/docs/how-to/tests.rst
@@ -8,7 +8,7 @@ Sometimes, it's helpful to log non-global metrics to an experimenent. To do so, 
 
     from lazyscribe import Project
 
-    project = Project()
+    project = Project(fpath="project.json", mode="w")
 
     with project.log(name="My experiment") as exp:
         with exp.log_test(name="My test", description="Demo test") as test:


### PR DESCRIPTION
See #28, p. 19.