### PR TITLE
Simplify `typing` annotations

### DIFF
--- a/docs/how-to/custom-artifact.rst
+++ b/docs/how-to/custom-artifact.rst
@@ -51,7 +51,7 @@ additional metadata to capture, this is where we would capture it
 .. code-block:: python
 
     from datetime import datetime
-    from typing import Any, ClassVar, Dict, Optional
+    from typing import Any, ClassVar, Optional
 
     from attrs import define
 
@@ -73,7 +73,7 @@ additional metadata to capture, this is where we would capture it
             value: Optional[Any] = None,
             fname: Optional[str] = None,
             created_at: Optional[datetime] = None,
-            writer_kwargs: Optional[Dict] = None,
+            writer_kwargs: Optional[dict] = None,
             **kwargs
         ):
             """Construct the handler class."""

--- a/lazyscribe/__init__.py
+++ b/lazyscribe/__init__.py
@@ -1,10 +1,8 @@
 """Import path."""
 
-from typing import List
-
 from lazyscribe._meta import __version__  # noqa: F401
 from lazyscribe.experiment import Experiment
 from lazyscribe.project import Project
 from lazyscribe.test import Test
 
-__all__: List[str] = ["Experiment", "Project", "Test"]
+__all__: list[str] = ["Experiment", "Project", "Test"]

--- a/lazyscribe/artifacts/__init__.py
+++ b/lazyscribe/artifacts/__init__.py
@@ -1,7 +1,5 @@
 """Import the handlers."""
 
-from typing import List, Type
-
 try:
     from importlib_metadata import entry_points
 except ImportError:
@@ -9,10 +7,10 @@ except ImportError:
 
 from lazyscribe.artifacts.base import Artifact
 
-__all__: List[str] = ["_get_handler"]
+__all__: list[str] = ["_get_handler"]
 
 
-def _get_handler(alias: str) -> Type[Artifact]:
+def _get_handler(alias: str) -> type[Artifact]:
     """Retrieve a specific handler based on the alias.
 
     Parameters

--- a/lazyscribe/artifacts/base.py
+++ b/lazyscribe/artifacts/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Optional
 
 from attrs import define, field
 
@@ -21,7 +21,7 @@ class Artifact(metaclass=ABCMeta):
         The filename of the artifact.
     value : Any
         The value for the artifact.
-    writer_kwargs : Dict
+    writer_kwargs : dict
         User provided keyword arguments for writing an artifact. Provided when
         the artifact is logged to an experiment.
 
@@ -54,7 +54,7 @@ class Artifact(metaclass=ABCMeta):
     name: str = field(eq=False)
     fname: str = field(eq=False)
     value: Any = field(eq=False)
-    writer_kwargs: Dict = field(eq=False)
+    writer_kwargs: dict = field(eq=False)
     created_at: datetime = field(eq=False)
 
     @classmethod
@@ -65,7 +65,7 @@ class Artifact(metaclass=ABCMeta):
         value: Optional[Any] = None,
         fname: Optional[str] = None,
         created_at: Optional[datetime] = None,
-        writer_kwargs: Optional[Dict] = None,
+        writer_kwargs: Optional[dict] = None,
         **kwargs,
     ):
         """Construct the artifact handler.
@@ -85,10 +85,10 @@ class Artifact(metaclass=ABCMeta):
             the name of the artifact and the suffix for the class.
         created_at : datetime, optional (default None)
             When the artifact was created. If not supplied, :py:meth:`datetime.now` will be used.
-        writer_kwargs : Dict, optional (default None)
+        writer_kwargs : dict, optional (default None)
             Keyword arguments for writing an artifact to the filesystem. Provided when an artifact
             is logged to an experiment.
-        **kwargs : Dict
+        **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.
         """

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -1,7 +1,7 @@
 """Joblib-based handler for pickle-serializable objects."""
 
 from datetime import datetime
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Optional
 
 from attrs import define
 from importlib_metadata import packages_distributions, version
@@ -53,7 +53,7 @@ class JoblibArtifact(Artifact):
         value: Optional[Any] = None,
         fname: Optional[str] = None,
         created_at: Optional[datetime] = None,
-        writer_kwargs: Optional[Dict] = None,
+        writer_kwargs: Optional[dict] = None,
         package: Optional[str] = None,
         **kwargs,
     ):
@@ -75,10 +75,10 @@ class JoblibArtifact(Artifact):
             The package name or root module name of the serializable python object.
             Note: this may be different from the distribution name. e.g ``scikit-learn`` is
             a distribution name, where as ``sklearn`` is the corresponding package name.
-        writer_kwargs : Dict, optional (default None)
+        writer_kwargs : dict, optional (default None)
             Keyword arguments for writing an artifact to the filesystem. Provided when an artifact
             is logged to an experiment.
-        **kwargs : Dict
+        **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.
         """

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -3,7 +3,7 @@
 import sys
 from datetime import datetime
 from json import dump, load
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Optional
 
 from attrs import define
 from slugify import slugify
@@ -34,7 +34,7 @@ class JSONArtifact(Artifact):
         value: Optional[Any] = None,
         fname: Optional[str] = None,
         created_at: Optional[datetime] = None,
-        writer_kwargs: Optional[Dict] = None,
+        writer_kwargs: Optional[dict] = None,
         **kwargs,
     ):
         """Construct the handler class.
@@ -51,10 +51,10 @@ class JSONArtifact(Artifact):
             the name of the artifact and the suffix for the class.
         created_at : datetime, optional (default None)
             When the artifact was created. If not supplied, :py:meth:`datetime.now` will be used.
-        writer_kwargs : Dict, optional (default None)
+        writer_kwargs : dict, optional (default None)
             Keyword arguments for writing an artifact to the filesystem. Provided when an artifact
             is logged to an experiment.
-        **kwargs : Dict
+        **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.
         """

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -5,10 +5,11 @@ import inspect
 import json
 import logging
 import warnings
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Optional, Union
 
 from attrs import Factory, asdict, define, field, fields, filters, frozen
 from fsspec.implementations.local import LocalFileSystem
@@ -105,16 +106,16 @@ class Experiment:
     fs: AbstractFileSystem = field(eq=False)
     author: str = Factory(getpass.getuser)
     last_updated_by: str = field()
-    metrics: Dict = Factory(lambda: {})
-    parameters: Dict = Factory(lambda: {})
+    metrics: dict = Factory(lambda: {})
+    parameters: dict = Factory(lambda: {})
     created_at: datetime = Factory(datetime.now)
     last_updated: datetime = Factory(datetime.now)
-    dependencies: Dict = field(eq=False, factory=lambda: {})
+    dependencies: dict = field(eq=False, factory=lambda: {})
     short_slug: str = field()
     slug: str = field()
-    tests: List[Union[Test, ReadOnlyTest]] = Factory(lambda: [])
-    artifacts: List[Artifact] = Factory(factory=lambda: [])
-    tags: List[str] = Factory(factory=lambda: [])
+    tests: list[Union[Test, ReadOnlyTest]] = Factory(lambda: [])
+    artifacts: list[Artifact] = Factory(factory=lambda: [])
+    tags: list[str] = Factory(factory=lambda: [])
 
     @dir.default
     def _dir_factory(self) -> Path:
@@ -400,12 +401,12 @@ class Experiment:
         except Exception as exc:
             raise exc
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Serialize the experiment to a dictionary.
 
         Returns
         -------
-        Dict
+        dict
             The experiment dictionary.
         """
         return asdict(

--- a/lazyscribe/linked.py
+++ b/lazyscribe/linked.py
@@ -6,7 +6,7 @@ The code for this module is lifted from
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 from attrs import define
 
@@ -26,7 +26,7 @@ class Node:
     data: Any = None
     next: Any = None
 
-    def to_list(self) -> List:
+    def to_list(self) -> list:
         """Convert the nodes to a de-duped list.
 
         Returns
@@ -74,7 +74,7 @@ class LinkedList:
             self.head = new
 
     @staticmethod
-    def from_list(data: List) -> LinkedList:
+    def from_list(data: list) -> LinkedList:
         """Convert a standard list to a linked list."""
         # Sort the list
         sorted_list = sorted(data)

--- a/lazyscribe/prefect/__init__.py
+++ b/lazyscribe/prefect/__init__.py
@@ -1,7 +1,5 @@
 """Import the tasks."""
 
-from typing import List
-
 from lazyscribe.prefect.experiment import (
     LazyExperiment,
     append_test,
@@ -16,7 +14,7 @@ from lazyscribe.prefect.project import (
 )
 from lazyscribe.prefect.test import LazyTest, log_test_metric
 
-__all__: List[str] = [
+__all__: list[str] = [
     "LazyExperiment",
     "LazyProject",
     "LazyTest",

--- a/lazyscribe/prefect/experiment.py
+++ b/lazyscribe/prefect/experiment.py
@@ -1,9 +1,10 @@
 """Prefect experiment tasks."""
 
 import getpass
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import prefect
 from prefect import Flow, Task, task
@@ -118,7 +119,7 @@ def append_test(experiment: Experiment, test: Test):
 
 
 @task(name="Add tag")
-def add_tag(experiment: Experiment, tags: Tuple[str], overwrite: bool):
+def add_tag(experiment: Experiment, tags: tuple[str], overwrite: bool):
     """Add tags to the experiment.
 
     Parameters

--- a/lazyscribe/prefect/project.py
+++ b/lazyscribe/prefect/project.py
@@ -1,8 +1,9 @@
 """Prefect project tasks."""
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Union
 from urllib.parse import urlparse
 
 import prefect
@@ -60,7 +61,7 @@ def merge_projects(base: Project, other: Project) -> Project:
 
 
 @task(name="Create tabular data", nout=2)
-def project_to_tabular(project: Project) -> Tuple[List, List]:
+def project_to_tabular(project: Project) -> tuple[list, list]:
     """Create tabular representations of the project.
 
     Parameters
@@ -70,9 +71,9 @@ def project_to_tabular(project: Project) -> Tuple[List, List]:
 
     Returns
     -------
-    List
+    list
         A global project list, with one entry per experiment.
-    List
+    list
         A tests level list.
     """
     return project.to_tabular()
@@ -90,7 +91,7 @@ class LazyProject(Task):
         The mode for opening the project. See :py:class:`lazyscribe.Project` for reference.
     author : str, optional (default None)
         The project author.
-    storage_options : Dict, optional (default None)
+    storage_options : dict, optional (default None)
         Storage options to pass to the filesystem initialization.
     **kwargs
         Keyword arguments for :py:class:`prefect.Task`.
@@ -101,7 +102,7 @@ class LazyProject(Task):
         fpath: str = "project.json",
         mode: Literal["r", "a", "w", "w+"] = "w",
         author: Optional[str] = None,
-        storage_options: Optional[Dict] = None,
+        storage_options: Optional[dict] = None,
         **kwargs,
     ):
         """Init method."""
@@ -118,7 +119,7 @@ class LazyProject(Task):
         fpath: Optional[str] = None,
         mode: Optional[Literal["r", "a", "w", "w+"]] = None,
         author: Optional[str] = None,
-        storage_options: Optional[Dict] = None,
+        storage_options: Optional[dict] = None,
     ) -> Project:
         """Instantiate a :py:class:`lazyscribe.Project`.
 
@@ -130,7 +131,7 @@ class LazyProject(Task):
             The mode for opening the project.
         author : str, optional (default None)
             The author for the project.
-        storage_options : Dict, optional (default None)
+        storage_options : dict, optional (default None)
             Storage options to pass to the filesystem initialization.
 
         Returns

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -6,10 +6,11 @@ import getpass
 import json
 import logging
 import warnings
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Dict, Iterator, List, Literal, Tuple
+from typing import Literal
 from urllib.parse import urlparse
 
 import fsspec
@@ -43,7 +44,7 @@ class Project:
     author : str, optional (default None)
         The project author. This author will be used for any new experiments or modifications to
         existing experiments. If not supplied, ``getpass.getuser()`` will be used.
-    storage_options : Dict, optional (default None)
+    storage_options : dict, optional (default None)
         Storage options to pass to the filesystem initialization. Will be passed to
         fsspec.filesystem.
 
@@ -75,8 +76,8 @@ class Project:
         self.storage_options = storage_options
 
         # If in ``r``, ``a``, or ``w+`` mode, read in the existing project.
-        self.experiments: List[Experiment | ReadOnlyExperiment] = []
-        self.snapshot: Dict = {}
+        self.experiments: list[Experiment | ReadOnlyExperiment] = []
+        self.snapshot: dict = {}
         self.fs = fsspec.filesystem(self.protocol, **storage_options)
 
         if mode not in ("r", "a", "w", "w+"):
@@ -321,7 +322,7 @@ class Project:
             if func(exp):
                 yield exp
 
-    def to_tabular(self) -> Tuple[List, List]:
+    def to_tabular(self) -> tuple[list, list]:
         """Create a dictionary that can be fed into ``pandas``.
 
         This method depends on the user consistently logging
@@ -330,7 +331,7 @@ class Project:
 
         Returns
         -------
-        List
+        list
             The ``experiments`` list. Each entry will represent an experiment,
             with the following keys:
 
@@ -357,7 +358,7 @@ class Project:
             (with the format ``("parameters", <parameter_name>)``) and one key
             per metric in the ``metrics`` dictionary (with the format
             ``("metrics", <metric_name>)``) for each experiment.
-        List
+        list
             The ``tests`` list. Each entry will represent a test, with the
             following keys:
 
@@ -381,8 +382,8 @@ class Project:
             per metric in the ``metrics`` dictionary (with the format
             ``("metrics", <metric_name>)``) for each test.
         """
-        exp_output: List = []
-        test_output: List = []
+        exp_output: list = []
+        test_output: list = []
 
         for exp in self:
             exp_output.append(

--- a/lazyscribe/test.py
+++ b/lazyscribe/test.py
@@ -1,6 +1,6 @@
 """Sub-population tests."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from attrs import Factory, define, frozen
 
@@ -30,8 +30,8 @@ class Test:
 
     name: str
     description: Optional[str] = Factory(lambda: None)
-    metrics: Dict = Factory(lambda: {})
-    parameters: Dict = Factory(lambda: {})
+    metrics: dict = Factory(lambda: {})
+    parameters: dict = Factory(lambda: {})
 
     def log_metric(self, name: str, value: Union[float, int]):
         """Log a metric to the test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,6 @@ select = [
 ignore = [
 	"C901",  # Function/method is too complex. (Add back in later.)
 	"E501",  # Line too long. Using formatter instead.
-	"UP035",  # ``typing.x`` is deprecated, use ``x`` instead
-	"UP006",  # ``typing.x`` is deprecated, use ``x`` instead
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Optional
 
 from slugify import slugify
 
@@ -22,7 +22,7 @@ class TestArtifact(Artifact):
         value: Optional[Any] = None,
         fname: Optional[str] = None,
         created_at: Optional[datetime] = None,
-        writer_kwargs: Optional[Dict] = None,
+        writer_kwargs: Optional[dict] = None,
         **kwargs,
     ):
         return cls(

--- a/tutorials/prefect.py
+++ b/tutorials/prefect.py
@@ -6,7 +6,6 @@ In this tutorial, we will demonstrate how you can use ``lazyscribe`` with ``pref
 """
 
 import json
-from typing import Tuple
 
 import numpy as np
 from prefect import Flow, task
@@ -22,7 +21,7 @@ from lazyscribe.prefect import LazyProject
 @task(name="Generate data", nout=2)
 def generate_data(
     n_samples: int = 1000, n_features: int = 10
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Generate classification data.
 
     Parameters


### PR DESCRIPTION
There were some deprecations in 3.9 (our minimal version now):
https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections