### PR TITLE
feat: Add YAML artifact handler

### DIFF
--- a/docs/how-to/artifact.rst
+++ b/docs/how-to/artifact.rst
@@ -67,6 +67,7 @@ Below, we have included a list of currently supported artifact handlers and thei
     * - :py:class:`lazyscribe.artifacts.YAMLArtifact`
       - yaml
       - Artifacts written using :py:meth:`yaml.dump` and read using :py:meth:`yaml.load`. You can specify the dumper using the ``Dumper`` keyword argument and the loader using the ``Loader`` keyword argument. Defaults to :py:class:`yaml.FullDumper` and :py:class:`yaml.SafeLoader` respectively if not specified.
+      - ``PyYAML``
 
 
 Loading and validation

--- a/docs/how-to/artifact.rst
+++ b/docs/how-to/artifact.rst
@@ -64,6 +64,9 @@ Below, we have included a list of currently supported artifact handlers and thei
       - joblib
       - Artifacts written using :py:meth:`joblib.dump` and read using :py:meth:`joblib.load`
       - ``joblib``
+    * - :py:class:`lazyscribe.artifacts.YAMLArtifact`
+      - yaml
+      - Artifacts written using :py:meth:`yaml.dump` and read using :py:meth:`yaml.load`. You can specify the dumper using the ``Dumper`` keyword argument and the loader using the ``Loader`` keyword argument. Defaults to :py:class:`yaml.FullDumper` and :py:class:`yaml.SafeLoader` respectively if not specified.
 
 Loading and validation
 ----------------------

--- a/docs/how-to/artifact.rst
+++ b/docs/how-to/artifact.rst
@@ -68,6 +68,7 @@ Below, we have included a list of currently supported artifact handlers and thei
       - yaml
       - Artifacts written using :py:meth:`yaml.dump` and read using :py:meth:`yaml.load`. You can specify the dumper using the ``Dumper`` keyword argument and the loader using the ``Loader`` keyword argument. Defaults to :py:class:`yaml.FullDumper` and :py:class:`yaml.SafeLoader` respectively if not specified.
 
+
 Loading and validation
 ----------------------
 

--- a/docs/how-to/custom-artifact.rst
+++ b/docs/how-to/custom-artifact.rst
@@ -23,7 +23,7 @@ the following mandatory class variables:
    Python object on read.
 
 Additional class variables are used to capture metadata about the environment
-or artifact. Let's create a handler for YAML files to demonstrate.
+or artifact. Let's create a handler for text files to demonstrate.
 
 .. code-block:: python
 
@@ -35,11 +35,11 @@ or artifact. Let's create a handler for YAML files to demonstrate.
     from lazyscribe.artifacts.base import Artifact
 
     @define(auto_attribs=True)
-    class YAMLArtifact(Artifact):
-        """Handler for YAML artifacts."""
+    class TextArtifact(Artifact):
+        """Handler for Text artifacts."""
 
-        alias: ClassVar[str] = "yaml"
-        suffix: ClassVar[str] = "yaml"
+        alias: ClassVar[str] = "text"
+        suffix: ClassVar[str] = "txt"
         binary: ClassVar[bool] = False
         output_only: ClassVar[bool] = False
 
@@ -58,11 +58,11 @@ additional metadata to capture, this is where we would capture it
     from lazyscribe.artifacts.base import Artifact
 
     @define(auto_attribs=True)
-    class YAMLArtifact(Artifact):
-        """Handler for YAML artifacts."""
+    class TextArtifact(Artifact):
+        """Handler for Text artifacts."""
 
-        alias: ClassVar[str] = "yaml"
-        suffix: ClassVar[str] = "yaml"
+        alias: ClassVar[str] = "text"
+        suffix: ClassVar[str] = "txt"
         binary: ClassVar[bool] = False
         output_only: ClassVar[bool] = False
 
@@ -78,13 +78,14 @@ additional metadata to capture, this is where we would capture it
             **kwargs
         ):
             """Construct the handler class."""
+            created_at = created_at or datetime.now()
             return cls(
                 name=name,
                 value=value,
                 writer_kwargs=writer_kwargs or {},
                 version=version,
-                fname=fname or f"{slugify(name)}.{cls.suffix}",
-                created_at=created_at or datetime.now(),
+                fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
+                created_at=created_at,
             )
 
 Finally, we have to write the I/O methods, ``read`` and ``write``. Both of these
@@ -92,10 +93,9 @@ methods should expect a file buffer from the ``fsspec`` filesystem.
 
 .. code-block:: python
 
-    import yaml
 
     @define(auto_attribs=True)
-    class YAMLArtifact(Artifact):
+    class TextArtifact(Artifact):
         ...
         @classmethod
         def read(cls, buf, **kwargs):
@@ -106,29 +106,29 @@ methods should expect a file buffer from the ``fsspec`` filesystem.
             buf : file-like object
                 The buffer from a ``fsspec`` filesystem.
             **kwargs
-                Keyword arguments for the read method.
+                Keyword arguments for compatibility.
 
             Returns
             -------
             Any
                 The artifact.
             """
-            return yaml.load(buf, Loader=yaml.SafeLoader, **kwargs)
+            return buf.read()
 
         @classmethod
         def write(cls, obj, buf, **kwargs):
-            """Write the content to a YAML file.
+            """Write the content to a Text file.
 
             Parameters
             ----------
             obj : object
-                The YAML-serializable object.
+                The Text-serializable object.
             buf : file-like object
                 The buffer from a ``fsspec`` filesystem.
             **kwargs
-                Keyword arguments for :py:meth:`yaml.dump`.
+                Keyword arguments for compatibility.
             """
-            yaml.dump(obj, buf, **kwargs)
+            buf.write(obj)
 
 You have a new custom handler!
 
@@ -142,15 +142,15 @@ Entry points (for packages)
 
 You can register your artifact handler using entry points in the
 ``lazyscribe.artifact_type`` group. For example, suppose we distributed our
-``YAMLArtifact`` class as ``myproject.artifacts.YAMLArtifact``. In the ``pyproject.toml``
+``TextArtifact`` class as ``myproject.artifacts.TextArtifact``. In the ``pyproject.toml``
 for ``myproject``, we can include the following:
 
 .. code-block:: toml
 
     [project.entry-points."lazyscribe.artifact_type"]
-    yaml = "myproject.artifacts:YAMLArtifact"
+    text = "myproject.artifacts:TextArtifact"
 
-Then, you can use :py:meth:`lazyscribe.Experiment.log_artifact` with ``handler="yaml"``.
+Then, you can use :py:meth:`lazyscribe.Experiment.log_artifact` with ``handler="text"``.
 
 Subclass scanning
 ~~~~~~~~~~~~~~~~~
@@ -161,14 +161,14 @@ in the module where you are logging experiments:
 
 .. code-block:: python
 
-    from mymodule import YAMLArtifact
+    from mymodule import TextArtifact
 
     from lazyscribe import Project
 
     project = Project(...)
 
     with project.log_experiment(...) as exp:
-        exp.log_artifact(..., handler="yaml")
+        exp.log_artifact(..., handler="text")
 
 This method works by looking for all available subclasses of :py:class:`lazyscribe.artifacts.base.Artifact`
 at runtime.

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -5,10 +5,8 @@ import yaml
 
 try:
     from yaml import CSafeLoader as SafeLoader
-    from yaml import CFullLoader as FullLoader
 except ImportError:
     from yaml import SafeLoader
-    from yaml import FullLoader
 from attrs import define
 from slugify import slugify
 
@@ -22,7 +20,6 @@ class YAMLArtifact(Artifact):
     suffix: ClassVar[str] = "yaml"
     binary: ClassVar[bool] = False
     output_only: ClassVar[bool] = False
-    loader: Literal["safe", "full"]
 
     @classmethod
     def construct(
@@ -63,13 +60,9 @@ class YAMLArtifact(Artifact):
         Any
             The artifact.
         """
-        if cls.loader == "safe":
-            loader = SafeLoader
-        elif cls.loader == "full":
-            loader = FullLoader
-        else:
-            raise ValueError("Loader must be 'safe' or 'full'")
-        return yaml.load(buf, Loader=loader, **kwargs)
+        if "Loader" not in kwargs:
+            kwargs["Loader"] = SafeLoader  # default to safe loader
+        return yaml.load(buf, **kwargs)
 
     @classmethod
     def write(cls, obj, buf, **kwargs):

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -10,7 +10,7 @@ import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeLoader  # type: ignore[assignment]
 from attrs import define
 from slugify import slugify
 

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -1,0 +1,87 @@
+
+from datetime import datetime
+from typing import Any, ClassVar, Literal, Optional
+import yaml
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+    from yaml import CFullLoader as FullLoader
+except ImportError:
+    from yaml import SafeLoader
+    from yaml import FullLoader
+from attrs import define
+from slugify import slugify
+
+from lazyscribe.artifacts.base import Artifact
+
+@define(auto_attribs=True)
+class YAMLArtifact(Artifact):
+    """Handler for YAML artifacts."""
+
+    alias: ClassVar[str] = "yaml"
+    suffix: ClassVar[str] = "yaml"
+    binary: ClassVar[bool] = False
+    output_only: ClassVar[bool] = False
+    loader: Literal["safe", "full"]
+
+    @classmethod
+    def construct(
+        cls,
+        name: str,
+        value: Any = None,
+        fname: str | None = None,
+        created_at: datetime | None = None,
+        writer_kwargs: dict | None = None,
+        version: int = 0,
+        **kwargs
+    ):
+        """Construct the handler class."""
+        created_at = created_at or datetime.now(),
+        return cls(
+            name=name,
+            value=value,
+            fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
+            writer_kwargs=writer_kwargs or {},
+            version=version,
+            created_at=created_at or datetime.now(),
+            loader=kwargs.get("loader") or "safe"
+        )
+    
+    @classmethod
+    def read(cls, buf, **kwargs):
+        """Read in the artifact.
+
+        Parameters
+        ----------
+        buf : file-like object
+            The buffer from a ``fsspec`` filesystem.
+        **kwargs
+            Keyword arguments for the read method.
+
+        Returns
+        -------
+        Any
+            The artifact.
+        """
+        if cls.loader == "safe":
+            loader = SafeLoader
+        elif cls.loader == "full":
+            loader = FullLoader
+        else:
+            raise ValueError("Loader must be 'safe' or 'full'")
+        return yaml.load(buf, Loader=loader, **kwargs)
+
+    @classmethod
+    def write(cls, obj, buf, **kwargs):
+        """Write the content to a YAML file.
+
+        Parameters
+        ----------
+        obj : object
+            The YAML-serializable object.
+        buf : file-like object
+            The buffer from a ``fsspec`` filesystem.
+        **kwargs
+            Keyword arguments for :py:meth:`yaml.dump`.
+        """
+        yaml.dump(obj, buf, **kwargs)

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -19,6 +19,7 @@ from lazyscribe.artifacts.base import Artifact
 
 LOG = logging.getLogger(__name__)
 
+
 @define(auto_attribs=True)
 class YAMLArtifact(Artifact):
     """Handler for YAML artifacts."""

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -33,15 +33,14 @@ class YAMLArtifact(Artifact):
         **kwargs
     ):
         """Construct the handler class."""
-        created_at = created_at or datetime.now(),
+        created_at = created_at or datetime.now()
         return cls(
             name=name,
             value=value,
             fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
             writer_kwargs=writer_kwargs or {},
             version=version,
-            created_at=created_at or datetime.now(),
-            loader=kwargs.get("loader") or "safe"
+            created_at=created_at,
         )
     
     @classmethod

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -9,7 +9,7 @@ import yaml
 
 try:
     from yaml import CSafeLoader as SafeLoader
-except ImportError:
+except ImportError:  # pragma: no branch
     from yaml import SafeLoader  # type: ignore[assignment]
 from attrs import define
 from slugify import slugify

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, ClassVar
 
@@ -16,6 +17,7 @@ from slugify import slugify
 
 from lazyscribe.artifacts.base import Artifact
 
+LOG = logging.getLogger(__name__)
 
 @define(auto_attribs=True)
 class YAMLArtifact(Artifact):
@@ -66,6 +68,7 @@ class YAMLArtifact(Artifact):
             The artifact.
         """
         if "Loader" not in kwargs:
+            LOG.debug("No loader provided, defaulting to SafeLoader")
             kwargs["Loader"] = SafeLoader  # default to safe loader
         return yaml.load(buf, **kwargs)
 

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -9,7 +9,7 @@ import yaml
 
 try:
     from yaml import CSafeLoader as SafeLoader
-except ImportError:  # pragma: no branch
+except ImportError:  # pragma: no cover
     from yaml import SafeLoader  # type: ignore[assignment]
 from attrs import define
 from slugify import slugify

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -1,5 +1,7 @@
 """PyYAML-based handler for YAML-serializable artifacts."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, ClassVar
 

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -1,6 +1,8 @@
+"""PyYAML-based handler for YAML-serializable artifacts."""
 
 from datetime import datetime
-from typing import Any, ClassVar, Literal, Optional
+from typing import Any, ClassVar
+
 import yaml
 
 try:
@@ -11,6 +13,7 @@ from attrs import define
 from slugify import slugify
 
 from lazyscribe.artifacts.base import Artifact
+
 
 @define(auto_attribs=True)
 class YAMLArtifact(Artifact):
@@ -30,19 +33,20 @@ class YAMLArtifact(Artifact):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int = 0,
-        **kwargs
+        **kwargs,
     ):
         """Construct the handler class."""
         created_at = created_at or datetime.now()
         return cls(
             name=name,
             value=value,
-            fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
+            fname=fname
+            or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
             writer_kwargs=writer_kwargs or {},
             version=version,
             created_at=created_at,
         )
-    
+
     @classmethod
     def read(cls, buf, **kwargs):
         """Read in the artifact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["readme", "version"]
 [project.optional-dependencies]
 build = ["build", "bumpver", "twine", "wheel"]
 docs = ["furo", "matplotlib", "pandas", "pillow", "prefect<2,>=1.0", "scikit-learn", "sphinx", "sphinx-gallery", "sphinx-inline-tabs"]
-qa = ["ruff==0.7.3", "edgetest", "mypy", "pip-tools", "types-python-slugify"]
+qa = ["ruff==0.7.3", "edgetest", "mypy", "pip-tools", "types-python-slugify", "types-PyYAML"]
 tests = ["scikit-learn", "prefect<2,>=1.0", "pytest", "pytest-cov", "time-machine"]
 dev = ["lazyscribe[build]", "lazyscribe[docs]", "lazyscribe[qa]", "lazyscribe[tests]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["readme", "version"]
 build = ["build", "bumpver", "twine", "wheel"]
 docs = ["furo", "matplotlib", "pandas", "pillow", "prefect<2,>=1.0", "scikit-learn", "sphinx", "sphinx-gallery", "sphinx-inline-tabs"]
 qa = ["ruff==0.7.3", "edgetest", "mypy", "pip-tools", "types-python-slugify", "types-PyYAML"]
-tests = ["scikit-learn", "prefect<2,>=1.0", "pytest", "pytest-cov", "time-machine"]
+tests = ["scikit-learn", "prefect<2,>=1.0", "pytest", "pytest-cov", "time-machine", "PyYAML"]
 dev = ["lazyscribe[build]", "lazyscribe[docs]", "lazyscribe[qa]", "lazyscribe[tests]"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 base = "lazyscribe.artifacts.base:Artifact"
 joblib = "lazyscribe.artifacts.joblib:JoblibArtifact"
 json = "lazyscribe.artifacts.json:JSONArtifact"
+yaml = "lazyscribe.artifacts.yaml:YAMLArtifact"
 
 ##############################################################################
 # Setuptools configuration

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -94,7 +94,7 @@ def test_yaml_handler_defaults_to_safeloader(tmp_path):
 
     assert data == out
 
-    # Test that it doesn't unserialize objects that need 
+    # Test that it doesn't unserialize objects that need
     # full loader
     data = [{"type": float}]
     handler = YAMLArtifact.construct(name="Unreadable")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -71,7 +71,7 @@ def test_yaml_handler(data, Loader, tmp_path):
     assert data == out
 
 
-def test_yaml_handler_defaults_to_safeloader(data, Loader, tmp_path):
+def test_yaml_handler_defaults_to_safeloader(tmp_path):
     """Test YAML handler defaults to safe loader."""
     location = tmp_path / "my-location"
     location.mkdir()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,12 +1,16 @@
 """Test the artifact handlers."""
 
 from datetime import datetime
+import zoneinfo
 
 import pytest
+import time_machine
+import yaml
 
 from lazyscribe.artifacts import _get_handler
 from lazyscribe.artifacts.joblib import JoblibArtifact
 from lazyscribe.artifacts.json import JSONArtifact
+from lazyscribe.artifacts.yaml import YAMLArtifact
 
 
 def test_json_handler(tmp_path):
@@ -28,6 +32,80 @@ def test_json_handler(tmp_path):
     assert (location / handler.fname).is_file()
 
     with open(location / handler.fname) as buf:
+        out = handler.read(buf)
+
+    assert data == out
+
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
+@pytest.mark.parametrize(
+    "data,Loader",
+    (
+        ([{"key": "value"}], yaml.SafeLoader),
+        ([{"key": "value"}], yaml.FullLoader),
+        ([{"type": float}], yaml.FullLoader),
+        ({"key": "value", "type": str}, yaml.FullLoader),
+    )
+)
+def test_yaml_handler(data, Loader, tmp_path):
+    """Test reading and writing YAML files with the handler."""
+    location = tmp_path / "my-location"
+    location.mkdir()
+    handler = YAMLArtifact.construct(name="My output file")
+
+    assert (
+        handler.fname
+        == f"my-output-file-{datetime.now().strftime('%Y%m%d%H%M%S')}.yaml"
+    )
+
+    with open(location / handler.fname, "w") as buf:
+        handler.write(data, buf)
+
+    assert (location / handler.fname).is_file()
+
+    with open(location / handler.fname) as buf:
+        out = handler.read(buf, Loader=Loader)
+
+    assert data == out
+
+def test_yaml_handler_defaults_to_safeloader(data, Loader, tmp_path):
+    """Test YAML handler defaults to safe loader."""
+    location = tmp_path / "my-location"
+    location.mkdir()
+
+    data = [{"key": "value"}]
+    handler = YAMLArtifact.construct(name="My output file")
+
+    assert (
+        handler.fname
+        == f"my-output-file-{datetime.now().strftime('%Y%m%d%H%M%S')}.yaml"
+    )
+
+    with open(location / handler.fname, "w") as buf:
+        handler.write(data, buf)
+
+    assert (location / handler.fname).is_file()
+
+    with open(location / handler.fname) as buf:
+        out = handler.read(buf)
+
+    assert data == out
+
+    data = [{"type": float}]
+    handler = YAMLArtifact.construct(name="Unreadable")
+
+    assert (
+        handler.fname
+        == f"unreadable-{datetime.now().strftime('%Y%m%d%H%M%S')}.yaml"
+    )
+
+    with open(location / handler.fname, "w") as buf:
+        handler.write(data, buf)
+
+    assert (location / handler.fname).is_file()
+
+    with open(location / handler.fname) as buf, pytest.raises(yaml.ConstructorError):
         out = handler.read(buf)
 
     assert data == out

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """Test the artifact handlers."""
 
-from datetime import datetime
 import zoneinfo
+from datetime import datetime
 
 import pytest
 import time_machine
@@ -36,6 +36,7 @@ def test_json_handler(tmp_path):
 
     assert data == out
 
+
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )
@@ -46,7 +47,7 @@ def test_json_handler(tmp_path):
         ([{"key": "value"}], yaml.FullLoader),
         ([{"type": float}], yaml.FullLoader),
         ({"key": "value", "type": str}, yaml.FullLoader),
-    )
+    ),
 )
 def test_yaml_handler(data, Loader, tmp_path):
     """Test reading and writing YAML files with the handler."""
@@ -68,6 +69,7 @@ def test_yaml_handler(data, Loader, tmp_path):
         out = handler.read(buf, Loader=Loader)
 
     assert data == out
+
 
 def test_yaml_handler_defaults_to_safeloader(data, Loader, tmp_path):
     """Test YAML handler defaults to safe loader."""
@@ -95,17 +97,17 @@ def test_yaml_handler_defaults_to_safeloader(data, Loader, tmp_path):
     data = [{"type": float}]
     handler = YAMLArtifact.construct(name="Unreadable")
 
-    assert (
-        handler.fname
-        == f"unreadable-{datetime.now().strftime('%Y%m%d%H%M%S')}.yaml"
-    )
+    assert handler.fname == f"unreadable-{datetime.now().strftime('%Y%m%d%H%M%S')}.yaml"
 
     with open(location / handler.fname, "w") as buf:
         handler.write(data, buf)
 
     assert (location / handler.fname).is_file()
 
-    with open(location / handler.fname) as buf, pytest.raises(yaml.ConstructorError):
+    with (
+        open(location / handler.fname) as buf,
+        pytest.raises(yaml.constructor.ConstructorError),
+    ):
         out = handler.read(buf)
 
     assert data == out

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -94,6 +94,8 @@ def test_yaml_handler_defaults_to_safeloader(tmp_path):
 
     assert data == out
 
+    # Test that it doesn't unserialize objects that need 
+    # full loader
     data = [{"type": float}]
     handler = YAMLArtifact.construct(name="Unreadable")
 
@@ -108,9 +110,7 @@ def test_yaml_handler_defaults_to_safeloader(tmp_path):
         open(location / handler.fname) as buf,
         pytest.raises(yaml.constructor.ConstructorError),
     ):
-        out = handler.read(buf)
-
-    assert data == out
+        handler.read(buf)
 
 
 def test_joblib_handler(tmp_path):


### PR DESCRIPTION
In this PR, I've added an artifact handler using PyYAML. Users can use pass-through args to choose which loader (or dumper) they want to use on logging or loading. I have also changed the how-to guide for custom artifacts to a `TextArtifact` as YAML is now built-in.