### PR TITLE
Fix from #84 @kuraga's comments

### DIFF
--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -106,8 +106,8 @@ class Repository:
         handler : str
             The name of the handler to use for the object.
         fname : str, optional (default None)
-            The filename for the artifact. If not provided, it will be derived from the
-            name of the artifact and the builtin suffix for each handler.
+            The filename for the artifact. If set to ``None`` or not provided, it will be derived
+            from the name of the artifact and the builtin suffix for each handler.
         overwrite : bool, optional (default False)
             Whether or not to overwrite an existing artifact with the same name. If set to ``True``,
             the previous artifact will be removed and overwritten with the current artifact.
@@ -120,6 +120,7 @@ class Repository:
         RuntimeError
             Raised if an artifact is supplied with the same name as an existing artifact and
             ``overwrite`` is set to ``False``.
+            Also raised if the repository is in read-only mode.
         """
         if self.mode == "r":
             raise RuntimeError("Repository is in read-only mode.")
@@ -164,12 +165,12 @@ class Repository:
         validate : bool, optional (default True)
             Whether or not to validate the runtime environment against the artifact
             metadata.
-        version: datetime | str | int, optional (default None)
+        version: datetime.datetime | str | int, optional (default None)
             The version of the artifact to load.
             Can be provided as a datetime corresponding to the ``created_at`` field,
-            a string corresponding to the ``created_at`` field in the format "%Y-%m-%dT%H:%M:%S" (e.g. "2025-01-25T12:36:22"),
-            or an integer version.
-            If not provided, defaults to the most recent version.
+            a string corresponding to the ``created_at`` field in the format ``"%Y-%m-%dT%H:%M:%S"``
+            (e.g. ``"2025-01-25T12:36:22"``), or an integer version.
+            If set to ``None`` or not provided, defaults to the most recent version.
         **kwargs : dict
             Keyword arguments for the handler read function.
 


### PR DESCRIPTION
After merging of #81, some my comments left untouched.
This PR fixes them in my way.
Each modification is contained in a separate (descriptive) commit (for discussion convenience).

Comments addressed in this PR:

* https://github.com/lazyscribe/lazyscribe/pull/81#discussion_r1943179535 (a7da8622b57584b54daf42909b1ac1c2bc4c2ae0),
* https://github.com/lazyscribe/lazyscribe/pull/81#discussion_r1940992449 (7fc01e012b2ea42931a738f685bc8ddac48420b7),
* https://github.com/lazyscribe/lazyscribe/pull/81#discussion_r1943206209 (e38fb87dac0b0ae0bcac6c2f0056651853d81393),
* https://github.com/lazyscribe/lazyscribe/pull/81#discussion_r1928836161 (cfc5e5e0c7dd88180625c75e334916e65d8695ad),
* https://github.com/lazyscribe/lazyscribe/pull/81#discussion_r1940954195 (f905890eed504c91118d9b0bdeaf526b8ddc384a).

This PR is draft-mode. Will squash it on readiness.

Thanks!