### PR TITLE
Use UTC everywhere

### DIFF
--- a/docs/how-to/custom-artifact.rst
+++ b/docs/how-to/custom-artifact.rst
@@ -50,7 +50,7 @@ additional metadata to capture, this is where we would capture it
 
 .. code-block:: python
 
-    from datetime import datetime
+    from datetime import datetime, timezone
     from typing import Any, ClassVar, Optional
 
     from attrs import define
@@ -78,7 +78,7 @@ additional metadata to capture, this is where we would capture it
             **kwargs
         ):
             """Construct the handler class."""
-            created_at = created_at or datetime.now()
+            created_at = created_at or datetime.now(timezone.utc)
             return cls(
                 name=name,
                 value=value,

--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -63,11 +63,11 @@ def serialize_artifacts(alist: list[Artifact]) -> Iterator[dict[str, Any]]:
 
 
 def utcnow() -> datetime:
-    """Return the time now in UTC.
+    """Return the naive datetime now in UTC.
 
     Returns
     -------
-    Any
-        Converted value for easy serialization.
+    datetime
+        Now in UTC, without timezone info.
     """
-    return datetime.now(timezone.utc).repalce(tzinfo=None)
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -1,7 +1,7 @@
 """Util methods."""
 
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from attrs import asdict, fields, filters
@@ -60,3 +60,14 @@ def serialize_artifacts(alist: list[Artifact]) -> Iterator[dict[str, Any]]:
         }
         for artifact in alist
     )
+
+
+def utcnow() -> datetime:
+    """Return the time now in UTC.
+
+    Returns
+    -------
+    Any
+        Converted value for easy serialization.
+    """
+    return datetime.now(timezone.utc)

--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -70,4 +70,4 @@ def utcnow() -> datetime:
     Any
         Converted value for easy serialization.
     """
-    return datetime.now(timezone.utc)
+    return datetime.now(timezone.utc).repalce(tzinfo=None)

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -10,6 +10,7 @@ from importlib_metadata import packages_distributions
 from importlib_metadata import version as importlib_version
 from slugify import slugify
 
+from lazyscribe._utils import utcnow
 from lazyscribe.artifacts.base import Artifact
 
 
@@ -112,7 +113,7 @@ class JoblibArtifact(Artifact):
             raise RuntimeError(
                 "Please install ``joblib`` to use this handler."
             ) from err
-        created_at = created_at or datetime.now()
+        created_at = created_at or utcnow()
         return cls(
             name=name,
             value=value,

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -10,6 +10,7 @@ from typing import Any, ClassVar
 from attrs import define
 from slugify import slugify
 
+from lazyscribe._utils import utcnow
 from lazyscribe.artifacts.base import Artifact
 
 
@@ -66,7 +67,7 @@ class JSONArtifact(Artifact):
         python_version = kwargs.get("python_version") or ".".join(
             str(i) for i in sys.version_info[:2]
         )
-        created_at = created_at or datetime.now()
+        created_at = created_at or utcnow()
         return cls(
             name=name,
             value=value,

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -8,6 +8,8 @@ from typing import Any, ClassVar
 
 import yaml
 
+from lazyscribe._utils import utcnow
+
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:  # pragma: no cover
@@ -41,7 +43,7 @@ class YAMLArtifact(Artifact):
         **kwargs,
     ):
         """Construct the handler class."""
-        created_at = created_at or datetime.now()
+        created_at = created_at or utcnow()
         return cls(
             name=name,
             value=value,

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -16,7 +16,7 @@ from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from slugify import slugify
 
-from lazyscribe._utils import serializer
+from lazyscribe._utils import serializer, utcnow
 from lazyscribe.artifacts import Artifact, _get_handler
 from lazyscribe.test import ReadOnlyTest, Test
 
@@ -43,9 +43,9 @@ class Experiment:
     parameters : dict, optional (default {})
         A dictionary of experiment parameters. The key must be a string but the value can be
         anything.
-    created_at : datetime, optional (default ``datetime.now()``)
+    created_at : datetime, optional (default ``utcnow()``)
         When the experiment was created.
-    last_updated : datetime, optional (default ``datetime.now()``)
+    last_updated : datetime, optional (default ``utcnow()``)
         When the experiment was last updated.
     dependencies : dict, optional (default None)
         A dictionary of upstream project experiments. The key is the short slug for the upstream
@@ -60,8 +60,8 @@ class Experiment:
     last_updated_by: str = field()
     metrics: dict = Factory(lambda: {})
     parameters: dict = Factory(lambda: {})
-    created_at: datetime = Factory(datetime.now)
-    last_updated: datetime = Factory(datetime.now)
+    created_at: datetime = Factory(utcnow)
+    last_updated: datetime = Factory(utcnow)
     dependencies: dict = field(eq=False, factory=lambda: {})
     short_slug: str = field()
     slug: str = field()
@@ -144,7 +144,7 @@ class Experiment:
         value : int or float
             Value of the metric.
         """
-        self.last_updated = datetime.now()
+        self.last_updated = utcnow()
         self.metrics[name] = value
 
     def log_parameter(self, name: str, value: Any):
@@ -159,7 +159,7 @@ class Experiment:
         value : Any
             The parameter itself.
         """
-        self.last_updated = datetime.now()
+        self.last_updated = utcnow()
         self.parameters[name] = value
 
     def tag(self, *args, overwrite: bool = False):
@@ -178,7 +178,7 @@ class Experiment:
         overwrite : bool, optional (default False)
             Whether to add or overwrite the new tags.
         """
-        self.last_updated = datetime.now()
+        self.last_updated = utcnow()
         new_tags_ = list(args)
         if overwrite:
             self.tags = new_tags_
@@ -223,7 +223,7 @@ class Experiment:
             ``overwrite`` is set to ``False``.
         """
         # Retrieve and construct the handler
-        self.last_updated = datetime.now()
+        self.last_updated = utcnow()
         handler_cls = _get_handler(handler)
         artifact_handler = handler_cls.construct(
             name=name,

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 import fsspec
 from attrs import asdict, fields, filters
 
-from lazyscribe._utils import serialize_artifacts
+from lazyscribe._utils import serialize_artifacts, utcnow
 from lazyscribe.artifacts import _get_handler
 from lazyscribe.artifacts.base import Artifact
 
@@ -124,7 +124,7 @@ class Repository:
         if self.mode == "r":
             raise RuntimeError("Repository is in read-only mode.")
         # Retrieve and construct the handler
-        self.last_updated = datetime.now()
+        self.last_updated = utcnow()
         artifacts_matching_name = [art for art in self.artifacts if art.name == name]
         version = (
             max(art.version for art in artifacts_matching_name) + 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, Optional
 
 from slugify import slugify
 
+from lazyscribe._utils import utcnow
 from lazyscribe.artifacts import Artifact
 
 
@@ -26,7 +27,7 @@ class TestArtifact(Artifact):
         version: int | None = None,
         **kwargs,
     ):
-        created_at = created_at or datetime.now()
+        created_at = created_at or utcnow()
         version = version if version is not None else 0
         return cls(
             name=name,
@@ -34,7 +35,7 @@ class TestArtifact(Artifact):
             writer_kwargs=writer_kwargs or {},
             fname=fname
             or f"{slugify(name)}-{created_at.strftime('%Y%m%d%H%M%S')}.{cls.suffix}",
-            created_at=created_at or datetime.now(),
+            created_at=created_at,
             version=version,
         )
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -2,17 +2,18 @@
 
 import sys
 import warnings
+import zoneinfo
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 import time_machine
-import zoneinfo
 from attrs.exceptions import FrozenInstanceError
 
 from lazyscribe.artifacts import _get_handler
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.test import ReadOnlyTest, Test
+
 
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
@@ -60,6 +61,7 @@ def test_experiment_logging():
     exp.tag("actually a failure", overwrite=True)
     assert exp.tags == ["actually a failure"]
 
+
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )
@@ -94,6 +96,7 @@ def test_experiment_serialization():
         "tags": [],
     }
 
+
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )
@@ -115,6 +118,7 @@ def test_experiment_to_tabular():
         ("short_slug", ""): "my-experiment",
         ("slug", ""): "my-experiment-" + today.strftime("%Y%m%d%H%M%S"),
     }
+
 
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
@@ -167,6 +171,7 @@ def test_experiment_artifact_logging_overwrite():
     exp.log_artifact(name="features", value=[3, 4, 5], handler="json", overwrite=True)
 
     assert exp.artifacts[0].value == [3, 4, 5]
+
 
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
@@ -230,6 +235,7 @@ def test_experiment_artifact_load_validation():
 
     with pytest.raises(RuntimeError):
         exp.load_artifact(name="estimator")
+
 
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
@@ -305,6 +311,7 @@ def test_frozen_test():
         test.name = "actually the test is not that"
 
     assert "lazyscribe.test.ReadOnlyTest" in str(test)
+
 
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -6,13 +6,17 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+import time_machine
+import zoneinfo
 from attrs.exceptions import FrozenInstanceError
 
 from lazyscribe.artifacts import _get_handler
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.test import ReadOnlyTest, Test
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_attrs_default():
     """Test any non-trivial experiment attributes."""
     today = datetime.now()
@@ -56,7 +60,9 @@ def test_experiment_logging():
     exp.tag("actually a failure", overwrite=True)
     assert exp.tags == ["actually a failure"]
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_serialization():
     """Test serializing the experiment to a dictionary."""
     today = datetime.now()
@@ -88,7 +94,9 @@ def test_experiment_serialization():
         "tags": [],
     }
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_to_tabular():
     """Test converting an experiment to a pandas-ready list."""
     today = datetime.now()
@@ -108,7 +116,9 @@ def test_experiment_to_tabular():
         ("slug", ""): "my-experiment-" + today.strftime("%Y%m%d%H%M%S"),
     }
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_artifact_logging_basic():
     """Test logging an artifact to the experiment."""
     today = datetime.now()
@@ -158,7 +168,9 @@ def test_experiment_artifact_logging_overwrite():
 
     assert exp.artifacts[0].value == [3, 4, 5]
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_artifact_load(tmp_path):
     """Test loading an experiment artifact from the disk."""
     location = tmp_path / "my-location"
@@ -219,7 +231,9 @@ def test_experiment_artifact_load_validation():
     with pytest.raises(RuntimeError):
         exp.load_artifact(name="estimator")
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_serialization_dependencies():
     """Test serializing an experiment with a dependency."""
     today = datetime.now()
@@ -292,7 +306,9 @@ def test_frozen_test():
 
     assert "lazyscribe.test.ReadOnlyTest" in str(test)
 
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_experiment_artifact_log_load_output_only(tmp_path):
     """Test loading an experiment artifact from the disk."""
     location = tmp_path / "my-location"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -74,6 +74,9 @@ def test_yaml_handler(data, Loader, tmp_path):
     assert data == out
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_yaml_handler_defaults_to_safeloader(tmp_path):
     """Test YAML handler defaults to safe loader."""
     location = tmp_path / "my-location"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -13,6 +13,9 @@ from lazyscribe.artifacts.json import JSONArtifact
 from lazyscribe.artifacts.yaml import YAMLArtifact
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_json_handler(tmp_path):
     """Test reading and writing JSON files with the handler."""
     location = tmp_path / "my-location"
@@ -113,6 +116,9 @@ def test_yaml_handler_defaults_to_safeloader(tmp_path):
         handler.read(buf)
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_joblib_handler(tmp_path):
     """Test reading and writing scikit-learn estimators with the joblib handler."""
     joblib = pytest.importorskip("joblib")

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -93,6 +93,9 @@ def test_prefect_experiment(tmp_path):
     assert exp_dict["tags"] == ["success"]
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 @pytest.mark.parametrize("parametrized", [True, False])
 def test_prefect_project(parametrized, tmp_path):
     """Test lazyscribe project integration with projects."""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -198,9 +198,6 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
         model_load = exp2.load_artifact(name="estimator")
 
 
-@time_machine.travel(
-    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
-)
 def test_save_project_artifact_multi_experiment(tmp_path):
     """Test running save on a project twice with multiple experiments and artifacts.
 
@@ -267,9 +264,6 @@ def test_save_project_artifact_multi_experiment(tmp_path):
     )
 
 
-@time_machine.travel(
-    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
-)
 def test_save_project_artifact_updated(tmp_path):
     """Test running save twice with an updated experiment.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,12 +1,15 @@
 """Test the project class."""
 
 import json
+import warnings
+import zoneinfo
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
 import fsspec
 import pytest
+import time_machine
 
 from lazyscribe import Project
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
@@ -17,6 +20,9 @@ CURR_DIR = Path(__file__).resolve().parent
 DATA_DIR = CURR_DIR / "data"
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 @pytest.mark.parametrize(
     "project_kwargs",
     [
@@ -80,6 +86,9 @@ def test_not_logging_experiment_readonly():
         assert len(project.experiments) == 0
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_save_project(tmp_path):
     """Test saving a project to an output JSON."""
     location = tmp_path / "my-project"
@@ -125,6 +134,9 @@ def test_save_project(tmp_path):
     ]
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_save_project_artifact(tmp_path):
     """Test saving a project with an artifact."""
     location = tmp_path / "my-project"
@@ -186,6 +198,9 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
         model_load = exp2.load_artifact(name="estimator")
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_save_project_artifact_multi_experiment(tmp_path):
     """Test running save on a project twice with multiple experiments and artifacts.
 
@@ -252,6 +267,9 @@ def test_save_project_artifact_multi_experiment(tmp_path):
     )
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_save_project_artifact_updated(tmp_path):
     """Test running save twice with an updated experiment.
 
@@ -555,9 +573,9 @@ def test_filter_project():
     assert out == expected
 
 
-import warnings
-
-
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 def test_save_project_artifact_output_only(tmp_path):
     """Test saving a project with an output only artifact."""
     location = tmp_path / "my-project"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+"""Test utils."""
+
+import zoneinfo
+from datetime import datetime
+
+import time_machine
+
+from lazyscribe._utils import utcnow
+
+
+def test_utcnow():
+    """Test UTCnow."""
+    with time_machine.travel(
+        datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        assert utcnow() == datetime(
+            2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+        )
+
+    with time_machine.travel(
+        datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("EST")), tick=False
+    ):
+        assert utcnow() == datetime(
+            2025, 1, 20, 18, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+        )
+        
+    with time_machine.travel(
+        datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("MST")), tick=False
+    ):
+        assert utcnow() == datetime(
+            2025, 1, 20, 20, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,20 +13,14 @@ def test_utcnow():
     with time_machine.travel(
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
     ):
-        assert utcnow() == datetime(
-            2025, 1, 20, 13, 23, 30
-        )
+        assert utcnow() == datetime(2025, 1, 20, 13, 23, 30)
 
     with time_machine.travel(
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("EST")), tick=False
     ):
-        assert utcnow() == datetime(
-            2025, 1, 20, 18, 23, 30
-        )
-        
+        assert utcnow() == datetime(2025, 1, 20, 18, 23, 30)
+
     with time_machine.travel(
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("MST")), tick=False
     ):
-        assert utcnow() == datetime(
-            2025, 1, 20, 20, 23, 30
-        )
+        assert utcnow() == datetime(2025, 1, 20, 20, 23, 30)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,19 +14,19 @@ def test_utcnow():
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
     ):
         assert utcnow() == datetime(
-            2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+            2025, 1, 20, 13, 23, 30
         )
 
     with time_machine.travel(
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("EST")), tick=False
     ):
         assert utcnow() == datetime(
-            2025, 1, 20, 18, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+            2025, 1, 20, 18, 23, 30
         )
         
     with time_machine.travel(
         datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("MST")), tick=False
     ):
         assert utcnow() == datetime(
-            2025, 1, 20, 20, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")
+            2025, 1, 20, 20, 23, 30
         )


### PR DESCRIPTION
- New custom function to return naive datetime now but in UTC.
- Use new custom util function everywhere where we used to use `datetime.now`
- Time travel everywhere where appropriate in tests.