### PR TITLE
fix: adding a check to ensure existing artifacts are not overwritten with null data and removing the w+ mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,19 @@ repos:
       - id: ruff-format
         types_or: [ python, jupyter ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.15.0
     hooks:
       - id: mypy
         exclude: ^(docs|tests)\/
         language_version: python3.9
-        args: [--namespace-packages, --explicit-package-bases, --ignore-missing-imports, --non-interactive, --install-types]
+        pass_filenames: false
+        args: [
+          --namespace-packages,
+          --explicit-package-bases,
+          --ignore-missing-imports,
+          --non-interactive,
+          --install-types
+        ]
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.5.27
     hooks:

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -30,14 +30,13 @@ class Repository:
     fpath : str | Path, optional (default "repository.json")
         The location of the repository file. If no repository file exists, this will be the location
         of the output JSON file when ``save`` is called.
-    mode : {"r", "a", "w", "w+"}, optional (default "w")
+    mode : {"r", "a", "w"}, optional (default "w")
         The mode for opening the repository.
 
         * ``r``: Repository loaded as read-only: no new artifacts can be logged.
         * ``a``: All existing artifacts will be loaded as
           read-only and new artifacts can be added.
         * ``w``: No existing artifacts will be loaded.
-        * ``w+``: All artifacts will be loaded in editable mode.
 
     Attributes
     ----------
@@ -48,7 +47,7 @@ class Repository:
     def __init__(
         self,
         fpath: str | Path = "repository.json",
-        mode: Literal["r", "a", "w", "w+"] = "w",
+        mode: Literal["r", "a", "w"] = "w",
         **storage_options,
     ):
         """Init method."""
@@ -62,14 +61,14 @@ class Repository:
         self.dir = self.fpath.parent
         self.storage_options = storage_options
 
-        # If in ``r``, ``a``, or ``w+`` mode, read in the existing repository.
+        # If in ``r`` or ``a`` mode, read in the existing repository.
         self.artifacts: list[Artifact] = []
         self.fs = fsspec.filesystem(self.protocol, **storage_options)
 
-        if mode not in ("r", "a", "w", "w+"):
+        if mode not in ("r", "a", "w"):
             raise ValueError("Please provide a valid ``mode`` value.")
         self.mode = mode
-        if mode in ("r", "a", "w+") and self.fs.isfile(self.fpath):
+        if mode in ("r", "a") and self.fs.isfile(self.fpath):
             self.load()
 
     def load(self):

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -273,6 +273,11 @@ class Repository:
             fmode = "wb" if artifact.binary else "w"
             artifact_dir = self.dir / artifact.name
             fpath = artifact_dir / artifact.fname
+            if self.fs.isfile(fpath):
+                LOG.debug(
+                    f"Artifact {artifact.name} v{artifact.version} already exists. Skipping..."
+                )
+                continue
 
             self.fs.makedirs(artifact_dir, exist_ok=True)
             LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -30,13 +30,14 @@ class Repository:
     fpath : str | Path, optional (default "repository.json")
         The location of the repository file. If no repository file exists, this will be the location
         of the output JSON file when ``save`` is called.
-    mode : {"r", "a", "w"}, optional (default "w")
+    mode : {"r", "a", "w", "w+"}, optional (default "w")
         The mode for opening the repository.
 
         * ``r``: Repository loaded as read-only: no new artifacts can be logged.
         * ``a``: All existing artifacts will be loaded as
           read-only and new artifacts can be added.
         * ``w``: No existing artifacts will be loaded.
+        * ``w+``: All artifacts will be loaded in editable mode.
 
     Attributes
     ----------
@@ -47,7 +48,7 @@ class Repository:
     def __init__(
         self,
         fpath: str | Path = "repository.json",
-        mode: Literal["r", "a", "w"] = "w",
+        mode: Literal["r", "a", "w", "w+"] = "w",
         **storage_options,
     ):
         """Init method."""
@@ -61,14 +62,14 @@ class Repository:
         self.dir = self.fpath.parent
         self.storage_options = storage_options
 
-        # If in ``r`` or ``a`` mode, read in the existing repository.
+        # If in ``r``, ``a``, or ``w+`` mode, read in the existing repository.
         self.artifacts: list[Artifact] = []
         self.fs = fsspec.filesystem(self.protocol, **storage_options)
 
-        if mode not in ("r", "a", "w"):
+        if mode not in ("r", "a", "w", "w+"):
             raise ValueError("Please provide a valid ``mode`` value.")
         self.mode = mode
-        if mode in ("r", "a") and self.fs.isfile(self.fpath):
+        if mode in ("r", "a", "w+") and self.fs.isfile(self.fpath):
             self.load()
 
     def load(self):

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -273,9 +273,11 @@ class Repository:
             fmode = "wb" if artifact.binary else "w"
             artifact_dir = self.dir / artifact.name
             fpath = artifact_dir / artifact.fname
-            if self.fs.isfile(fpath):
+            if self.fs.isfile(fpath) and artifact.created_at <= datetime.fromtimestamp(
+                self.fs.info(fpath)["created"]
+            ):
                 LOG.debug(
-                    f"Artifact {artifact.name} v{artifact.version} already exists. Skipping..."
+                    f"Artifact {artifact.name} v{artifact.version} already exists and has not been updated"
                 )
                 continue
 


### PR DESCRIPTION
## Description

### Original Bug

In v0.7.0, we have the following bug:

```python
from lazyscribe.repository import Repository

repo = Repository()
repo.log_artifact("my-dict", {"a": 1}, handler="json")

repo.save()  # Everything is good so far

repo = Repository(mode="a")
repo.log_artifact("my-dict-2", {"b": 2}, handler="json")

repo.save()  # No error is thrown, but now the "my-dict" JSON file is null
```

this is because we were saving every artifact, regardless of whether it had been loaded by the user.

### Fix

In this PR, I have copied the logic from `Project.save` to only touch the filesystem when the artifact is newer than the file.