### PR TITLE
feat!: using a new `dirty` flag to describe whether an artifact or experiment needs to be persisted

### DIFF
--- a/docs/how-to/custom-artifact.rst
+++ b/docs/how-to/custom-artifact.rst
@@ -74,7 +74,8 @@ additional metadata to capture, this is where we would capture it
             fname: str | None = None,
             created_at: datetime | None = None,
             writer_kwargs: dict | None = None,
-            version: int | None = None
+            version: int | None = None,
+            dirty: bool = False,
             **kwargs
         ):
             """Construct the handler class."""
@@ -86,6 +87,7 @@ additional metadata to capture, this is where we would capture it
                 version=version,
                 fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
                 created_at=created_at,
+                dirty=dirty,
             )
 
 Finally, we have to write the I/O methods, ``read`` and ``write``. Both of these

--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -49,6 +49,7 @@ def serialize_artifacts(alist: list[Artifact]) -> Iterator[dict[str, Any]]:
                 filter=filters.exclude(
                     fields(type(artifact)).value,
                     fields(type(artifact)).writer_kwargs,
+                    fields(type(artifact)).dirty,
                 ),
                 value_serializer=lambda _, __, value: value.isoformat(
                     timespec="seconds"

--- a/lazyscribe/artifacts/base.py
+++ b/lazyscribe/artifacts/base.py
@@ -28,6 +28,10 @@ class Artifact(metaclass=ABCMeta):
         the artifact is logged to an experiment.
     version : int
         Version of the artifact.
+    dirty : bool
+        Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
+        or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
+        on whether the artifact is new or has been updated.
 
     Attributes
     ----------
@@ -61,6 +65,7 @@ class Artifact(metaclass=ABCMeta):
     writer_kwargs: dict = field(eq=False)
     created_at: datetime = field(eq=False)
     version: int = field(eq=False)
+    dirty: bool = field(eq=False)
 
     @classmethod
     @abstractmethod
@@ -72,6 +77,7 @@ class Artifact(metaclass=ABCMeta):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int = 0,
+        dirty: bool = False,
         **kwargs,
     ):
         """Construct the artifact handler.
@@ -96,6 +102,10 @@ class Artifact(metaclass=ABCMeta):
             is logged to an experiment.
         version : int, optional (default 0)
             Integer version to be used for versioning artifacts.
+        dirty : bool, optional (default False)
+            Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
+            or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
+            on whether the artifact is new or has been updated.
         **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -59,6 +59,7 @@ class JoblibArtifact(Artifact):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int = 0,
+        dirty: bool = False,
         package: str | None = None,
         **kwargs,
     ):
@@ -85,6 +86,10 @@ class JoblibArtifact(Artifact):
             is logged to an experiment.
         version : int, optional (default 0)
             Integer version to be used for versioning artifacts.
+        dirty : bool, optional (default False)
+            Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
+            or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
+            on whether the artifact is new or has been updated.
         **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.
@@ -122,6 +127,7 @@ class JoblibArtifact(Artifact):
             created_at=created_at,
             writer_kwargs=writer_kwargs or {},
             version=version,
+            dirty=dirty,
             package=package,
             package_version=kwargs.get("package_version")
             or importlib_version(distribution),

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -39,6 +39,7 @@ class JSONArtifact(Artifact):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int = 0,
+        dirty: bool = False,
         **kwargs,
     ):
         """Construct the handler class.
@@ -60,6 +61,10 @@ class JSONArtifact(Artifact):
             is logged to an experiment.
         version : int, optional (default 0)
             Integer version to be used for versioning artifacts.
+        dirty : bool, optional (default False)
+            Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
+            or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
+            on whether the artifact is new or has been updated.
         **kwargs : dict
             Other keyword arguments.
             Usually class attributes obtained from a project JSON.
@@ -77,6 +82,7 @@ class JSONArtifact(Artifact):
             created_at=created_at,
             python_version=python_version,
             version=version,
+            dirty=dirty,
         )
 
     @classmethod

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -40,6 +40,7 @@ class YAMLArtifact(Artifact):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int = 0,
+        dirty: bool = False,
         **kwargs,
     ):
         """Construct the handler class."""
@@ -49,9 +50,10 @@ class YAMLArtifact(Artifact):
             value=value,
             fname=fname
             or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
+            created_at=created_at,
             writer_kwargs=writer_kwargs or {},
             version=version,
-            created_at=created_at,
+            dirty=dirty,
         )
 
     @classmethod

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -231,6 +231,7 @@ class Experiment:
             fname=fname,
             created_at=self.last_updated,
             writer_kwargs=kwargs,
+            dirty=True,
         )
         for index, artifact in enumerate(self.artifacts):
             if artifact.name == name:

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -314,7 +314,9 @@ class Experiment:
                     )
                 # Read in the artifact
                 mode = "rb" if curr_handler.binary else "r"
-                with self.fs.open(self.dir / self.path / artifact.fname, mode) as buf:
+                with self.fs.open(
+                    str(self.dir / self.path / artifact.fname), mode
+                ) as buf:
                     out = curr_handler.read(buf, **kwargs)
                 if artifact.output_only:
                     warnings.warn(

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -83,7 +83,7 @@ class Project:
         if mode not in ("r", "a", "w", "w+"):
             raise ValueError("Please provide a valid ``mode`` value.")
         self.mode = mode
-        if mode in ("r", "a", "w+") and self.fs.isfile(self.fpath):
+        if mode in ("r", "a", "w+") and self.fs.isfile(str(self.fpath)):
             self.load()
 
         self.author = getpass.getuser() if author is None else author
@@ -95,7 +95,7 @@ class Project:
         be loaded in read-only mode. If opened in editable mode, existing experiments
         will be loaded in editable mode.
         """
-        with self.fs.open(self.fpath, "r") as infile:
+        with self.fs.open(str(self.fpath), "r") as infile:
             data = json.load(infile)
         for idx, entry in enumerate(data):
             data[idx]["created_at"] = datetime.fromisoformat(entry["created_at"])
@@ -181,7 +181,7 @@ class Project:
                     self[slug].last_updated_by = self.author
 
         data = list(self)
-        with self.fs.open(self.fpath, "w") as outfile:
+        with self.fs.open(str(self.fpath), "w") as outfile:
             json.dump(data, outfile, sort_keys=True, indent=4)
 
         for exp in self.experiments:
@@ -205,9 +205,9 @@ class Project:
                     )
                     continue
 
-                self.fs.makedirs(exp.dir / exp.path, exist_ok=True)
+                self.fs.makedirs(str(exp.dir / exp.path), exist_ok=True)
                 LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")
-                with self.fs.open(fpath, fmode) as buf:
+                with self.fs.open(str(fpath), fmode) as buf:
                     artifact.write(artifact.value, buf, **artifact.writer_kwargs)
                     if artifact.output_only:
                         warnings.warn(

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -209,6 +209,8 @@ class Project:
                 LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")
                 with self.fs.open(str(fpath), fmode) as buf:
                     artifact.write(artifact.value, buf, **artifact.writer_kwargs)
+                    # Reset the `dirty` flag since we have the updated artifact on disk
+                    artifact.dirty = False
                     if artifact.output_only:
                         warnings.warn(
                             f"Artifact '{artifact.name}' is added. It is not meant to be read back as Python Object",

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -137,7 +137,9 @@ class Project:
                     handler_cls = _get_handler(artifact.pop("handler"))
                     created_at = datetime.fromisoformat(artifact.pop("created_at"))
                     artifacts.append(
-                        handler_cls.construct(**artifact, created_at=created_at)
+                        handler_cls.construct(
+                            **artifact, created_at=created_at, dirty=False
+                        )
                     )
 
             if self.mode in ("r", "a"):
@@ -197,11 +199,7 @@ class Project:
             for artifact in exp.artifacts:
                 fmode = "wb" if artifact.binary else "w"
                 fpath = exp.dir / exp.path / artifact.fname
-                if self.fs.isfile(
-                    fpath
-                ) and artifact.created_at <= datetime.fromtimestamp(
-                    self.fs.info(fpath)["created"]
-                ):
+                if not artifact.dirty:
                     LOG.debug(
                         f"Artifact '{artifact.name}' already exists and has not been updated"
                     )

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -69,12 +69,12 @@ class Repository:
         if mode not in ("r", "a", "w", "w+"):
             raise ValueError("Please provide a valid ``mode`` value.")
         self.mode = mode
-        if mode in ("r", "a", "w+") and self.fs.isfile(self.fpath):
+        if mode in ("r", "a", "w+") and self.fs.isfile(str(self.fpath)):
             self.load()
 
     def load(self):
         """Load existing artifacts."""
-        with self.fs.open(self.fpath, "r") as infile:
+        with self.fs.open(str(self.fpath), "r") as infile:
             data = json.load(infile)
 
         artifacts = []
@@ -248,7 +248,7 @@ class Repository:
             )
         # Read in the artifact
         mode = "rb" if curr_handler.binary else "r"
-        with self.fs.open(self.dir / artifact.name / artifact.fname, mode) as buf:
+        with self.fs.open(str(self.dir / artifact.name / artifact.fname), mode) as buf:
             out = curr_handler.read(buf, **kwargs)
         if artifact.output_only:
             warnings.warn(
@@ -268,7 +268,7 @@ class Repository:
             raise RuntimeError("Repository is in read-only mode.")
 
         data = list(self)
-        with self.fs.open(self.fpath, "w") as outfile:
+        with self.fs.open(str(self.fpath), "w") as outfile:
             json.dump(data, outfile, sort_keys=True, indent=4)
 
         for artifact in self.artifacts:
@@ -282,9 +282,9 @@ class Repository:
                 )
                 continue
 
-            self.fs.makedirs(artifact_dir, exist_ok=True)
+            self.fs.makedirs(str(artifact_dir), exist_ok=True)
             LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")
-            with self.fs.open(fpath, fmode) as buf:
+            with self.fs.open(str(fpath), fmode) as buf:
                 artifact.write(artifact.value, buf, **artifact.writer_kwargs)
                 if artifact.output_only:
                     warnings.warn(

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -286,6 +286,8 @@ class Repository:
             LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")
             with self.fs.open(str(fpath), fmode) as buf:
                 artifact.write(artifact.value, buf, **artifact.writer_kwargs)
+                # Reset the `dirty` flag since we have the updated artifact on disk
+                artifact.dirty = False
                 if artifact.output_only:
                     warnings.warn(
                         f"Artifact '{artifact.name}' is added. It is not meant to be read back as Python Object",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ class TestArtifact(Artifact):
         created_at: datetime | None = None,
         writer_kwargs: dict | None = None,
         version: int | None = None,
+        dirty: bool = False,
         **kwargs,
     ):
         created_at = created_at or utcnow()
@@ -39,6 +40,7 @@ class TestArtifact(Artifact):
             or f"{slugify(name)}-{created_at.strftime('%Y%m%d%H%M%S')}.{cls.suffix}",
             created_at=created_at,
             version=version,
+            dirty=dirty,
         )
 
     @classmethod

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -28,6 +28,7 @@ def test_attrs_default():
     assert exp.slug == f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}"
     assert exp.path == Path(".", f"my-experiment-{today.strftime('%Y%m%d%H%M%S')}")
     assert "lazyscribe.experiment.Experiment" in str(exp)
+    assert exp.dirty is False
 
 
 def test_experiment_logging():
@@ -52,6 +53,7 @@ def test_experiment_logging():
     ]
     assert exp.tags == ["success"]
     assert "lazyscribe.test.Test" in str(test)
+    assert exp.dirty
 
     # Add another tag without overwriting
     exp.tag("huge success")
@@ -126,9 +128,11 @@ def test_experiment_to_tabular():
 def test_experiment_artifact_logging_basic():
     """Test logging an artifact to the experiment."""
     today = datetime.now()
+
     exp = Experiment(name="My experiment", project=Path("project.json"), author="root")
     exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
     JSONArtifact = _get_handler("json")
+
     assert isinstance(exp.artifacts[0], JSONArtifact)
     assert exp.to_dict() == {
         "name": "My experiment",
@@ -154,6 +158,7 @@ def test_experiment_artifact_logging_basic():
         "tests": [],
         "tags": [],
     }
+    assert exp.dirty
 
 
 def test_experiment_artifact_logging_overwrite():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -64,6 +64,16 @@ def test_experiment_logging():
     assert exp.tags == ["actually a failure"]
 
 
+def test_not_logging_test():
+    """Test not logging a test when raising an error."""
+    exp = Experiment(name="My experiment", project=Path("project.json"))
+    with pytest.raises(ValueError), exp.log_test(name="My test") as test:
+        test.log_metric("name-subpop", 0.3)
+        raise ValueError("An error.")
+
+    assert len(exp.tests) == 0
+
+
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -167,6 +167,7 @@ def test_joblib_handler(tmp_path):
             package_version=sklearn.__version__,
             joblib_version=joblib.__version__,
             version=None,
+            dirty=False,
         )
     ) == handler
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -67,6 +67,12 @@ def test_logging_experiment(project_kwargs):
         project["not a real experiment"]
 
 
+def test_invalid_project_mode():
+    """Test instantiating a project with an invalid mode."""
+    with pytest.raises(ValueError):
+        _ = Project(author="root", mode="fake-mode")
+
+
 def test_not_logging_experiment():
     """Test not logging an experiment when raising an error."""
     project = Project(author="root")
@@ -80,11 +86,14 @@ def test_not_logging_experiment():
 def test_not_logging_experiment_readonly():
     """Test trying to log an experiment in read only mode."""
     project = Project(fpath=DATA_DIR / "project.json", mode="r")
+    context_manager = project.log(name="New experiment")
+    with pytest.raises(RuntimeError):
+        _ = context_manager.__enter__()
 
-    with pytest.raises(RuntimeError), project.log(name="My experiment") as exp:
-        exp.log_metric("name", 0.5)
+    context_manager.__exit__(None, None, None)
 
-        assert len(project.experiments) == 0
+    assert len(project.experiments) == 1
+    assert "new-experiment" not in project
 
 
 @time_machine.travel(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -150,6 +150,7 @@ def test_save_project_artifact(tmp_path):
 
     project.save()
 
+    assert project["my-experiment"].artifacts[0].dirty is False
     assert project_location.is_file()
 
     features_fname = f"features-{today.strftime('%Y%m%d%H%M%S')}.json"
@@ -169,7 +170,6 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
     location = tmp_path / "my-project"
     location.mkdir()
     project_location = location / "project.json"
-    today = datetime.now()
 
     datasets = pytest.importorskip("sklearn.datasets")
     svm = pytest.importorskip("sklearn.svm")
@@ -184,6 +184,7 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
 
     project.save()
 
+    assert project["my-experiment"].artifacts[0].dirty is False
     assert project_location.is_file()
     assert (
         location

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -60,6 +60,8 @@ def test_save_repository(tmp_path):
     repository.log_artifact("my-dict", {"a": 1}, handler="json")
 
     repository.save()
+
+    assert repository["my-dict"].dirty is False
     assert repository_location.is_file()
 
     with open(repository_location) as infile:
@@ -97,14 +99,20 @@ def test_save_repository_multi(tmp_path):
     repository.log_artifact("my-dict", {"a": 1}, handler="json")
 
     repository.save()
+
+    assert repository["my-dict"].dirty is False
     assert repository_location.is_file()
 
     # Read in the repository again and log a separate artifact
     repository_read = Repository(repository_location, mode="a")
     repository_read.log_artifact("my-dict-2", {"b": 2}, handler="json")
 
+    assert repository_read["my-dict"].dirty is False
+    assert repository_read["my-dict-2"].dirty
+
     repository_read.save()
 
+    assert repository_read["my-dict"].dirty is False
     with open(repository_location) as infile:
         serialized = json.load(infile)
 


### PR DESCRIPTION
## Description

s/o @kuraga in [this comment](https://github.com/lazyscribe/lazyscribe/pull/96#issuecomment-2660204084).

In this PR, I have added the `dirty` flag that @kuraga suggested in #96. Essentially, artifacts are only written to disk on `save` when the flag is `True`. It is only `True` when constructed through the `log_artifact` methods in `Repository` and `Experiment`.

On the question of whether it's a "breaking change" -- I made two adjustments to the test suite:

1. Updating the `construct` method signature for the test handler,
2. Updating our manual construction of the handler in a project-level test.

I have also implemented the `dirty` flag for experiments. With this feature, we can delete the `snapshot` attribute of `lazyscribe.Project`.