### PR TITLE
fix!: handle string project filepaths

### DIFF
--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -188,14 +188,14 @@ class Project:
             LOG.info(f"Saving artifacts for {exp.slug}")
             for artifact in exp.artifacts:
                 fmode = "wb" if artifact.binary else "w"
-                fpath = exp.dir / exp.path / artifact.fname
+                fpath = exp.path / artifact.fname
                 if not artifact.dirty:
                     LOG.debug(
                         f"Artifact '{artifact.name}' already exists and has not been updated"
                     )
                     continue
 
-                self.fs.makedirs(str(exp.dir / exp.path), exist_ok=True)
+                self.fs.makedirs(str(exp.path), exist_ok=True)
                 LOG.debug(f"Saving '{artifact.name}' to {fpath!s}...")
                 with self.fs.open(str(fpath), fmode) as buf:
                     artifact.write(artifact.value, buf, **artifact.writer_kwargs)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -202,8 +202,8 @@ def test_experiment_artifact_load(tmp_path):
     )
     exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
     # Need to write the artifact to disk
-    fpath = exp.dir / exp.path / exp.artifacts[0].fname
-    exp.fs.makedirs(exp.dir / exp.path, exist_ok=True)
+    fpath = exp.path / exp.artifacts[0].fname
+    exp.fs.makedirs(exp.path, exist_ok=True)
     with exp.fs.open(fpath, "w") as buf:
         exp.artifacts[0].write(exp.artifacts[0].value, buf)
 
@@ -350,8 +350,8 @@ def test_experiment_artifact_log_load_output_only(tmp_path):
         )
 
     # Need to write the artifact to disk
-    fpath = exp.dir / exp.path / exp.artifacts[0].fname
-    exp.fs.makedirs(exp.dir / exp.path, exist_ok=True)
+    fpath = exp.path / exp.artifacts[0].fname
+    exp.fs.makedirs(exp.path, exist_ok=True)
     with exp.fs.open(fpath, "w") as buf:
         exp.artifacts[0].write(exp.artifacts[0].value, buf)
     today = datetime.now()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -195,7 +195,7 @@ def test_save_project_artifact_str_path(tmp_path):
 
     assert project["my-experiment"].dirty is False
     assert project["my-experiment"].artifacts[0].dirty is False
-    assert project_location.is_file()
+    assert Path(project_location).is_file()
 
     features_fname = f"features-{today.strftime('%Y%m%d%H%M%S')}.json"
     assert (

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -176,6 +176,7 @@ def test_save_project_artifact(tmp_path):
 
     assert artifact == [0, 1, 2]
 
+
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -208,6 +208,9 @@ def test_save_project_artifact_str_path(tmp_path):
     assert artifact == [0, 1, 2]
 
 
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
 @patch("lazyscribe.artifacts.joblib.importlib_version", side_effect=["1.2.2", "0.0.0"])
 def test_save_project_artifact_failed_validation(mock_version, tmp_path):
     """Test saving and loading project with an artifact."""


### PR DESCRIPTION
Removes duplication of directory structure when string path is passed on initialization of a `Project`.

Closes: #105.