### PR TITLE
feat!: Replace `RuntimeError` with custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ or editable mode ("w+"):
 
 ```python
 project = Project("project.json", mode="r")
-with project.log(name="New experiment") as exp:  # Raises a RuntimeError
+with project.log(name="New experiment") as exp:  # Raises a ReadOnlyError
     ...
 ```

--- a/lazyscribe/artifacts/__init__.py
+++ b/lazyscribe/artifacts/__init__.py
@@ -31,7 +31,7 @@ def _get_handler(alias: str) -> type[Artifact]:
             try:
                 mod = full_artifact_class.load()
             except ImportError as imp:
-                raise RuntimeError(
+                raise ImportError(
                     f"Unable to import handler for {alias} through entry points"
                 ) from imp
 

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -12,6 +12,7 @@ from slugify import slugify
 
 from lazyscribe._utils import utcnow
 from lazyscribe.artifacts.base import Artifact
+from lazyscribe.exception import ArtifactError
 
 
 @define(auto_attribs=True)
@@ -115,7 +116,7 @@ class JoblibArtifact(Artifact):
         try:
             import joblib
         except ImportError as err:
-            raise RuntimeError(
+            raise ArtifactError(
                 "Please install ``joblib`` to use this handler."
             ) from err
         created_at = created_at or utcnow()

--- a/lazyscribe/exception.py
+++ b/lazyscribe/exception.py
@@ -1,0 +1,25 @@
+"""Custom exceptions for lazyscribe."""
+
+
+class ReadOnlyError(Exception):
+    """Raised when a project or repository is opened in read-only mode and write operations are tried."""
+
+    pass
+
+
+class ArtifactError(Exception):
+    """Base exception for artifact errors."""
+
+    pass
+
+
+class ArtifactLogError(Exception):
+    """Raised when an artifact cannot be logged."""
+
+    pass
+
+
+class ArtifactLoadError(Exception):
+    """Raised when an artifact cannot be loaded."""
+
+    pass

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -18,6 +18,7 @@ from slugify import slugify
 
 from lazyscribe._utils import serializer, utcnow
 from lazyscribe.artifacts import Artifact, _get_handler
+from lazyscribe.exception import ArtifactLoadError, ArtifactLogError
 from lazyscribe.test import ReadOnlyTest, Test
 
 LOG = logging.getLogger(__name__)
@@ -225,7 +226,7 @@ class Experiment:
 
         Raises
         ------
-        RuntimeError
+        ArtifactLogError
             Raised if an artifact is supplied with the same name as an existing artifact and
             ``overwrite`` is set to ``False``.
         """
@@ -252,7 +253,7 @@ class Experiment:
                         )
                     break
                 else:
-                    raise RuntimeError(
+                    raise ArtifactLogError(
                         f"An artifact with name {name} already exists in the experiment. Please "
                         "use another name or set ``overwrite=True`` to replace the artifact."
                     )
@@ -284,6 +285,12 @@ class Experiment:
         -------
         object
             The artifact.
+
+        Raises
+        ------
+        ArtifactLoadError
+            If ``validate`` and runtime environment does not match artifact metadata.
+            Or if there is no artifact found with the name provided.
         """
         for artifact in self.artifacts:
             if artifact.name == name:
@@ -315,7 +322,7 @@ class Experiment:
                         fields(type(artifact)).value,
                         fields(type(artifact)).created_at,
                     )
-                    raise RuntimeError(
+                    raise ArtifactLoadError(
                         "Runtime environments do not match. Artifact parameters:\n\n"
                         f"{json.dumps(asdict(artifact, filter=field_filters))}"
                         "\n\nCurrent parameters:\n\n"
@@ -335,7 +342,7 @@ class Experiment:
                     )
                 break
         else:
-            raise ValueError(f"No artifact with name {name}")
+            raise ArtifactLoadError(f"No artifact with name {name}")
 
         return out
 

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 import fsspec
 
 from lazyscribe.artifacts import _get_handler
+from lazyscribe.exception import ReadOnlyError
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.linked import LinkedList, merge
 from lazyscribe.test import ReadOnlyTest, Test
@@ -167,7 +168,7 @@ class Project:
         This includes saving any artifact data.
         """
         if self.mode == "r":
-            raise RuntimeError("Project is in read-only mode.")
+            raise ReadOnlyError("Project is in read-only mode.")
         elif self.mode == "w+":
             for exp in self.experiments:
                 if exp.dirty:
@@ -255,12 +256,12 @@ class Project:
 
         Raises
         ------
-        RuntimeError
+        ReadOnlyError
             Raised when trying to log a new experiment when the project is in
             read-only mode.
         """
         if self.mode == "r":
-            raise RuntimeError("Project is in read-only mode.")
+            raise ReadOnlyError("Project is in read-only mode.")
         self.experiments.append(other)
 
     @contextmanager
@@ -279,12 +280,12 @@ class Project:
 
         Raises
         ------
-        RuntimeError
+        ReadOnlyError
             Raised when trying to log a new experiment when the project is in
             read-only mode.
         """
         if self.mode == "r":
-            raise RuntimeError("Project is in read-only mode.")
+            raise ReadOnlyError("Project is in read-only mode.")
         experiment = Experiment(
             name=name, project=self.fpath, fs=self.fs, author=self.author, dirty=True
         )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -11,6 +11,7 @@ import time_machine
 from attrs.exceptions import FrozenInstanceError
 
 from lazyscribe.artifacts import _get_handler
+from lazyscribe.exception import ArtifactLoadError, ArtifactLogError
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.test import ReadOnlyTest, Test
 
@@ -178,7 +179,7 @@ def test_experiment_artifact_logging_overwrite():
     JSONArtifact = _get_handler("json")
     assert isinstance(exp.artifacts[0], JSONArtifact)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ArtifactLogError):
         exp.log_artifact(name="features", value=[3, 4, 5], handler="json")
 
     assert exp.artifacts[0].value == [0, 1, 2]
@@ -248,7 +249,7 @@ def test_experiment_artifact_load_validation():
     # Edit the experiment parameters to make sure the validation fails
     exp.artifacts[0].package_version = "0.0.0"
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ArtifactLoadError):
         exp.load_artifact(name="estimator")
 
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -229,7 +229,7 @@ def test_experiment_artifact_load_keyerror(tmp_path):
         name="My experiment", project=location / "project.json", author="root"
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ArtifactLoadError):
         exp.load_artifact(name="features")
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -11,6 +11,7 @@ from lazyscribe.artifacts import _get_handler
 from lazyscribe.artifacts.joblib import JoblibArtifact
 from lazyscribe.artifacts.json import JSONArtifact
 from lazyscribe.artifacts.yaml import YAMLArtifact
+from lazyscribe.exception import ArtifactError
 
 
 @time_machine.travel(
@@ -225,5 +226,5 @@ def test_get_handler_import_error(mock_entry_points):
     mock_plugin_import.load.side_effect = ImportError()
 
     mock_entry_points.return_value = [mock_plugin_import]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ArtifactError):
         _get_handler(alias="dummy")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -11,7 +11,6 @@ from lazyscribe.artifacts import _get_handler
 from lazyscribe.artifacts.joblib import JoblibArtifact
 from lazyscribe.artifacts.json import JSONArtifact
 from lazyscribe.artifacts.yaml import YAMLArtifact
-from lazyscribe.exception import ArtifactError
 
 
 @time_machine.travel(

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -226,5 +226,5 @@ def test_get_handler_import_error(mock_entry_points):
     mock_plugin_import.load.side_effect = ImportError()
 
     mock_entry_points.return_value = [mock_plugin_import]
-    with pytest.raises(ArtifactError):
+    with pytest.raises(ImportError):
         _get_handler(alias="dummy")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -12,7 +12,7 @@ import pytest
 import time_machine
 
 from lazyscribe import Project
-from lazyscribe.exception import ReadOnlyError
+from lazyscribe.exception import ArtifactLoadError, ReadOnlyError
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.test import ReadOnlyTest, Test
 from tests.conftest import TestArtifact
@@ -244,7 +244,7 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
     ).is_file()
 
     # Reload project and validate experiment
-    with pytest.raises(ReadOnlyError):
+    with pytest.raises(ArtifactLoadError):
         project2 = Project(project_location, mode="r")
         exp2 = project2["my-experiment"]
         model_load = exp2.load_artifact(name="estimator")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -12,6 +12,7 @@ import pytest
 import time_machine
 
 from lazyscribe import Project
+from lazyscribe.exception import ReadOnlyError
 from lazyscribe.experiment import Experiment, ReadOnlyExperiment
 from lazyscribe.test import ReadOnlyTest, Test
 from tests.conftest import TestArtifact
@@ -87,7 +88,7 @@ def test_not_logging_experiment_readonly():
     """Test trying to log an experiment in read only mode."""
     project = Project(fpath=DATA_DIR / "project.json", mode="r")
     context_manager = project.log(name="New experiment")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ReadOnlyError):
         _ = context_manager.__enter__()
 
     context_manager.__exit__(None, None, None)
@@ -243,7 +244,7 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
     ).is_file()
 
     # Reload project and validate experiment
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ReadOnlyError):
         project2 = Project(project_location, mode="r")
         exp2 = project2["my-experiment"]
         model_load = exp2.load_artifact(name="estimator")
@@ -431,7 +432,7 @@ def test_load_project_readonly():
     )
 
     assert project.experiments == [expected]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ReadOnlyError):
         project.save()
 
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -12,6 +12,7 @@ import pytest
 import time_machine
 
 from lazyscribe.artifacts.base import Artifact
+from lazyscribe.exception import ArtifactLoadError, ReadOnlyError
 from lazyscribe.repository import Repository
 from tests.conftest import TestArtifact
 
@@ -36,12 +37,12 @@ def test_readonly():
     """Test trying to log an artifact and save in read only mode."""
     repository = Repository(fpath=DATA_DIR / "repository.json", mode="r")
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ReadOnlyError):
         repository.log_artifact("name", [1, 2, 3], handler="json")
 
     assert len(repository.artifacts) == 4
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ReadOnlyError):
         repository.save()
 
     assert len(repository.artifacts) == 4
@@ -317,7 +318,7 @@ def test_save_repository_artifact_failed_validation(mock_version, tmp_path):
     assert (location / "estimator" / "estimator-20250120132330.joblib").is_file()
 
     # Reload repository and validate experiment
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ArtifactLoadError):
         repository2 = Repository(repository_location, mode="r")
         repository2.load_artifact(name="estimator")
 


### PR DESCRIPTION
This PR replaces the generic `RuntimeError` with custom errors so that users can catch our exceptions directly without matching other errors..