### PR TITLE
feat(repository): `asof` version matching to allow users to get the latest version of an artifact as of a given datetime

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ cloudpickle==3.1.1
     #   prefect
 colorama==0.4.6
     # via commitizen
-commitizen==4.2.1
+commitizen==4.2.2
     # via lazyscribe (pyproject.toml)
 contourpy==1.3.0
     # via matplotlib
@@ -211,7 +211,7 @@ prefect==1.4.1
     # via lazyscribe (pyproject.toml)
 prompt-toolkit==3.0.50
     # via questionary
-psutil==6.1.1
+psutil==7.0.0
     # via distributed
 pycparser==2.22
     # via cffi

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -234,6 +234,39 @@ class Repository:
 
         return out
 
+    def get_artifact_metadata(
+        self,
+        name: str,
+        version: datetime | str | int | None = None,
+        match: Literal["asof", "exact"] = "exact",
+    ) -> dict[str, Any]:
+        """Retrieve the metadata for an artifact.
+
+        Parameters
+        ----------
+        name : str
+            The name of the artifact to load.
+        version : datetime.datetime | str | int, optional (default None)
+            The version of the artifact to load.
+            Can be provided as a datetime corresponding to the ``created_at`` field,
+            a string corresponding to the ``created_at`` field in the format ``"%Y-%m-%dT%H:%M:%S"``
+            (e.g. ``"2025-01-25T12:36:22"``), or an integer version.
+            If set to ``None`` or not provided, defaults to the most recent version.
+        match : "asof" | "exact", optional (default "exact")
+            Matching logic. Only relevant for ``str`` and ``datetime.datetime`` values for
+            ``version``. ``exact`` will provide an artifact with the exact ``created_at``
+            value provided. ``asof`` will provide the most recent version as of the
+            ``version`` value.
+
+        Returns
+        -------
+        dict
+            The artifact metadata.
+        """
+        artifact = self._search_artifact_versions(name, version, match)
+
+        return next(serialize_artifacts([artifact]))
+
     def save(self):
         """Save the repository data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ readme = {file = ["README.md"], content-type = "text/markdown"}
 version = "0.7.1"
 tag_format = "v$version"
 update_changelog_on_bump = true
-major_version_zero = true
 version_files = [
     "lazyscribe/_meta.py:__version__",
 	"docs/conf.py:version",

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -431,3 +431,23 @@ def test_repository_asof_search(tmp_path):
     )
 
     assert art == repository.load_artifact(name="my-dict", version=datetime(2025, 3, 1))
+
+
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
+def test_retrieve_artifact_meta():
+    """Test retrieving artifact metadata."""
+    repository = Repository()
+    repository.log_artifact("my-dict", {"a": 1}, handler="json")
+
+    data = repository.get_artifact_metadata("my-dict")
+
+    assert data == {
+        "created_at": "2025-01-20T13:23:30",
+        "fname": "my-dict-20250120132330.json",
+        "handler": "json",
+        "name": "my-dict",
+        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+        "version": 0,
+    }

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -383,3 +383,51 @@ def test_repository_artifact_output_only(tmp_path):
         assert "Artifact 'features' is not the original Python Object" in str(
             w[-1].message
         )
+
+
+def test_invalid_match_strategy():
+    """Test raising an error with an invalid value for ``match``."""
+    repository = Repository()
+    repository.log_artifact("my-dict", {"a": 1}, handler="json")
+
+    with pytest.raises(ValueError):
+        repository._search_artifact_versions(
+            "my-dict", version=datetime(2025, 1, 1), match="fake"
+        )
+
+
+def test_repository_asof_search(tmp_path):
+    """Test retrieving artifacts using ``asof``."""
+    location = tmp_path / "my-repository"
+    location.mkdir()
+    repository_location = location / "repository.json"
+
+    repository = Repository(repository_location)
+
+    # Log artifacts using time-travel to get different creation dates
+    with time_machine.travel(
+        datetime(2025, 1, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        repository.log_artifact("my-dict", {"a": 1}, handler="json")
+    with time_machine.travel(
+        datetime(2025, 2, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        repository.log_artifact("my-dict", {"a": 2}, handler="json")
+    with time_machine.travel(
+        datetime(2025, 3, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        repository.log_artifact("my-dict", {"a": 3}, handler="json")
+
+    repository.save()
+
+    art = repository.load_artifact(
+        name="my-dict", version=datetime(2025, 1, 15), match="asof"
+    )
+
+    assert art == repository.load_artifact(name="my-dict", version=datetime(2025, 1, 1))
+
+    art = repository.load_artifact(
+        name="my-dict", version=datetime(2025, 3, 15), match="asof"
+    )
+
+    assert art == repository.load_artifact(name="my-dict", version=datetime(2025, 3, 1))


### PR DESCRIPTION
# Description

In this PR, I've added an argument to `load_artifact` called `match`. If the user provides a `str` or `datetime.datetime` object for `version` along with `match="asof"`, they will retrieve the latest version of the artifact as of that given date. I have also added a method for retrieving artifact metadata, as this can be helpful when parsing environment constraints.