### PR TITLE
Annotations, documentation comments, stricter checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,14 @@ repos:
     rev: v1.16.0
     hooks:
       - id: mypy
-        exclude: ^(docs|tests)\/
+        exclude: (^docs\/|^lazyscribe\/prefect\/^tests\/)
         language_version: python3.9
         pass_filenames: false
         args: [
           --namespace-packages,
           --explicit-package-bases,
           --ignore-missing-imports,
+          --disallow-untyped-defs,
           --non-interactive,
           --install-types
         ]

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Once you've finished, save the project to ``project.json``:
 project.save()
 ```
 
-Later on, you can read the project back in read-only mode ("r"), append mode ("a"),
-or editable mode ("w+"):
+Later on, you can read the project back in read-only mode (`"r"`), append mode (`"a"`),
+or editable mode (`"w+"`):
 
 ```python
 project = Project("project.json", mode="r")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,9 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
+
+"""Documentation configuration."""
+
 import os
 import sys
 

--- a/docs/how-to/artifact.rst
+++ b/docs/how-to/artifact.rst
@@ -18,15 +18,15 @@ to a unique folder based on experiment slug:
     with project.log("My experiment") as exp:
         exp.path
 
-This will return ``Path("./my-experiment-YYYYMMDDHHMMSS")``, where the datetime
+This will return ``pathlib.Path("./my-experiment-YYYYMMDDHHMMSS")``, where the datetime
 corresponds to the ``created_at`` attribute.
 
 .. important::
 
   Unless you log an artifact, this directory will not be created automatically.
 
-To associate an artifact with your experiment, use :py:meth:`lazyscribe.Experiment.log_artifact`.
-Serialization is delegated to a subclass of :py:class:`lazyscribe.artifacts.Artifact`.
+To associate an artifact with your experiment, use :py:meth:`lazyscribe.experiment.Experiment.log_artifact`.
+Serialization is delegated to a subclass of :py:class:`lazyscribe.artifacts.base.Artifact`.
 
 .. code-block:: python
     :caption: Persisting a ``scikit-learn`` estimator with ``joblib``.
@@ -44,8 +44,8 @@ Serialization is delegated to a subclass of :py:class:`lazyscribe.artifacts.Arti
 
 In the case of code failures, we want to minimize the chance that you need to clean up orphaned
 experiment data. For this reason, artifacts are *not persisted to the filesystem* when you call
-:py:meth:`lazyscribe.Experiment.log_artifact`. Artifacts are **only** saved when you
-call :py:meth:`lazyscribe.Project.save`.
+:py:meth:`lazyscribe.experiment.Experiment.log_artifact`. Artifacts are **only** saved when you
+call :py:meth:`lazyscribe.project.Project.save`.
 
 Below, we have included a list of currently supported artifact handlers and their aliases:
 
@@ -56,15 +56,15 @@ Below, we have included a list of currently supported artifact handlers and thei
       - Alias
       - Description
       - Additional requirements
-    * - :py:class:`lazyscribe.artifacts.JSONArtifact`
+    * - :py:class:`lazyscribe.artifacts.json.JSONArtifact`
       - json
       - Artifacts written using :py:meth:`json.dump` and read using :py:meth:`json.load`
       - N/A
-    * - :py:class:`lazyscribe.artifacts.JoblibArtifact`
+    * - :py:class:`lazyscribe.artifacts.joblib.JoblibArtifact`
       - joblib
       - Artifacts written using :py:meth:`joblib.dump` and read using :py:meth:`joblib.load`
       - ``joblib``
-    * - :py:class:`lazyscribe.artifacts.YAMLArtifact`
+    * - :py:class:`lazyscribe.artifacts.yaml.YAMLArtifact`
       - yaml
       - Artifacts written using :py:meth:`yaml.dump` and read using :py:meth:`yaml.load`. You can specify the dumper using the ``Dumper`` keyword argument and the loader using the ``Loader`` keyword argument. Defaults to :py:class:`yaml.FullDumper` and :py:class:`yaml.SafeLoader` respectively if not specified.
       - ``PyYAML``
@@ -73,7 +73,7 @@ Below, we have included a list of currently supported artifact handlers and thei
 Loading and validation
 ----------------------
 
-To load an artifact, use :py:meth:`lazyscribe.Experiment.load_artifact`.
+To load an artifact, use :py:meth:`lazyscribe.experiment.Experiment.load_artifact`.
 
 .. code-block:: python
     :emphasize-lines: 5
@@ -86,7 +86,7 @@ To load an artifact, use :py:meth:`lazyscribe.Experiment.load_artifact`.
 
 When an artifact is persisted to the filesystem, the handler may save environment
 parameters to use for validation when attempting to load the artifact into python.
-For example, when persisting a ``scikit-learn`` model object with the :py:class:`lazyscribe.artifacts.JoblibArtifact`,
+For example, when persisting a ``scikit-learn`` model object with the :py:class:`lazyscribe.artifacts.joblib.JoblibArtifact`,
 it will include the ``scikit-learn`` and ``joblib`` versions in the artifact metadata.
 If the metadata doesn't match with a handler constructed in the current runtime environment, ``lazyscribe`` will raise
 an error. You can disable validation using ``validate=False``:

--- a/docs/how-to/basic.rst
+++ b/docs/how-to/basic.rst
@@ -1,7 +1,7 @@
 Create a basic project
 ======================
 
-To create your first project, instantiate the :py:class:`lazyscribe.Project` class.
+To create your first project, instantiate the :py:class:`lazyscribe.project.Project` class.
 
 .. code-block:: python
 
@@ -17,10 +17,10 @@ Then, use the context manager to create an experiment and log it back to the pro
         exp.log_metric("metric", 0.3)
         exp.log_parameter("param", "value")
 
-When the context manager exits, the experiment will be appended to the ``Project.experiments`` list.
+When the context manager exits, the experiment will be appended to the :py:attr:`lazyscribe.project.Project.experiments` list.
 Using a list allows us to preserve the order and reference a copy when associating it with the project.
 If you want to avoid using the context manager, simply instantiate your own experiment and append it
-to the ``Project.experiments`` list.
+to the :py:attr:`lazyscribe.project.Project.experiments` list.
 
 .. code-block:: python
 
@@ -31,7 +31,7 @@ to the ``Project.experiments`` list.
     exp.log_parameter("param", "value")
     project.append(exp)
 
-Once you've finished, save the project to the filesystem using :py:meth:`lazyscribe.Project.save`
+Once you've finished, save the project to the filesystem using :py:meth:`lazyscribe.project.Project.save`
 method:
 
 .. code-block:: python

--- a/docs/how-to/custom-artifact.rst
+++ b/docs/how-to/custom-artifact.rst
@@ -51,7 +51,8 @@ additional metadata to capture, this is where we would capture it
 .. code-block:: python
 
     from datetime import datetime, timezone
-    from typing import Any, ClassVar, Optional
+    from io import IOBase
+    from typing import Any, ClassVar
 
     from attrs import define
 
@@ -74,19 +75,19 @@ additional metadata to capture, this is where we would capture it
             fname: str | None = None,
             created_at: datetime | None = None,
             writer_kwargs: dict | None = None,
-            version: int | None = None,
+            version: int = 0,
             dirty: bool = True,
-            **kwargs
-        ):
+            **kwargs: Any
+        ) -> TextArtifact:
             """Construct the handler class."""
             created_at = created_at or datetime.now(timezone.utc)
             return cls(
                 name=name,
                 value=value,
-                writer_kwargs=writer_kwargs or {},
-                version=version,
                 fname=fname or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
                 created_at=created_at,
+                writer_kwargs=writer_kwargs or {},
+                version=version,
                 dirty=dirty,
             )
 
@@ -96,40 +97,17 @@ methods should expect a file buffer from the ``fsspec`` filesystem.
 .. code-block:: python
 
 
-    @define(auto_attribs=True)
     class TextArtifact(Artifact):
         ...
+
         @classmethod
-        def read(cls, buf, **kwargs):
-            """Read in the artifact.
-
-            Parameters
-            ----------
-            buf : file-like object
-                The buffer from a ``fsspec`` filesystem.
-            **kwargs
-                Keyword arguments for compatibility.
-
-            Returns
-            -------
-            Any
-                The artifact.
-            """
+        def read(cls, buf: IOBase, **kwargs: Any) -> Any:
+            """Read in the artifact."""
             return buf.read()
 
         @classmethod
-        def write(cls, obj, buf, **kwargs):
-            """Write the content to a Text file.
-
-            Parameters
-            ----------
-            obj : object
-                The Text-serializable object.
-            buf : file-like object
-                The buffer from a ``fsspec`` filesystem.
-            **kwargs
-                Keyword arguments for compatibility.
-            """
+        def write(cls, obj: Any, buf: IOBase, **kwargs: Any) -> None:
+            """Write the content to a text file."""
             buf.write(obj)
 
 You have a new custom handler!
@@ -152,7 +130,7 @@ for ``myproject``, we can include the following:
     [project.entry-points."lazyscribe.artifact_type"]
     text = "myproject.artifacts:TextArtifact"
 
-Then, you can use :py:meth:`lazyscribe.Experiment.log_artifact` with ``handler="text"``.
+Then, you can use :py:meth:`lazyscribe.experiment.Experiment.log_artifact` with ``handler="text"``.
 
 Subclass scanning
 ~~~~~~~~~~~~~~~~~

--- a/docs/how-to/dependencies.rst
+++ b/docs/how-to/dependencies.rst
@@ -30,7 +30,7 @@ name "My experiment", you would have
     The path to ``other-project.json`` is relative to the path to the current project JSON.
 
 
-When you load the experiment through :py:class:`lazyscribe.Project`, the dependencies
+When you load the experiment through :py:class:`lazyscribe.project.Project`, the dependencies
 will be accessible through a dictionary, using the ``short_slug`` as a key:
 
 .. code-block:: python

--- a/docs/how-to/external-fs.rst
+++ b/docs/how-to/external-fs.rst
@@ -9,13 +9,14 @@ for example usage and available protocols.
 .. code-block:: python
 
     from lazyscribe import Project
+    from typing import Any
 
     fpath = "s3://path/to/my/project.json"
-    storage_options = {
+    storage_options: dict[str, Any] = {
         "username": "user",
         "password": "pswrd"
     }
-    
+
     project = Project(fpath=fpath, **storage_options)
 
 From there, you can use your project as normal.

--- a/docs/how-to/filter.rst
+++ b/docs/how-to/filter.rst
@@ -2,7 +2,7 @@ Filter experiments within your project
 ======================================
 
 In this guide, we will discuss how you can use a function to iterate through and
-filter experiments. First, create a :py:class:`lazyscribe.Project`.
+filter experiments. First, create a :py:class:`lazyscribe.project.Project`.
 
 .. code-block:: python
 
@@ -27,8 +27,8 @@ Then, let's log a couple of experiments.
         exp.log_parameter("build_period", "6M")
 
 Suppose you want to look at all experiments with a 6 month build period. We can use
-:py:meth:`lazyscribe.Project.filter` to do so. All we have to do is write a lambda
-function that takes in :py:class:`lazyscribe.Experiment` and outputs a boolean.
+:py:meth:`lazyscribe.project.Project.filter` to do so. All we have to do is write a lambda
+function that takes in :py:class:`lazyscribe.experiment.Experiment` and outputs a boolean.
 
 .. code-block:: python
 
@@ -36,5 +36,5 @@ function that takes in :py:class:`lazyscribe.Experiment` and outputs a boolean.
         project.filter(func=lambda x: x.parameters["build_period"] == "6M")
     )
 
-This will return our final two experiments as a list of :py:class:`lazyscribe.Experiment`
+This will return our final two experiments as a list of :py:class:`lazyscribe.experiment.Experiment`
 objects.

--- a/docs/how-to/merge.rst
+++ b/docs/how-to/merge.rst
@@ -8,7 +8,7 @@ same underlying project.
 TL;DR
 -----
 
-To perform a project merge, run :py:class:`lazyscribe.Project.merge`:
+To perform a project merge, run :py:class:`lazyscribe.project.Project.merge`:
 
 .. code-block:: python
     :emphasize-lines: 6

--- a/docs/how-to/readonly.rst
+++ b/docs/how-to/readonly.rst
@@ -7,7 +7,7 @@ project.
 Read-only mode
 --------------
 
-If you open a :py:class:`lazyscribe.Project` with ``mode="r"``, all experiments will be
+If you open a :py:class:`lazyscribe.project.Project` with ``mode="r"``, all experiments will be
 loaded into a :py:class:`lazyscribe.experiment.ReadOnlyExperiment` class. You **cannot**
 
 #. set any attributes directly for an experiment,
@@ -24,9 +24,9 @@ Editable mode
 -------------
 
 If you open a project with ``mode="w+"``, you have complete control. All experiments will be loaded
-into an editable :py:class:`lazyscribe.Experiment` class and you can make any changes.
+into an editable :py:class:`lazyscribe.experiment.Experiment` class and you can make any changes.
 
 .. note::
 
-    When you save the updated JSON, the ``last_updated_by`` experiment attribute will be updated to
+    When you save the project, the ``last_updated_by`` experiment attribute will be updated to
     match the ``author`` that opened the project in editable mode.

--- a/docs/how-to/tabular.rst
+++ b/docs/how-to/tabular.rst
@@ -2,7 +2,7 @@ Represent the project as a table
 ================================
 
 To aid in visualization and comparison, ``lazyscribe`` has a built-in method
-:py:meth:`lazyscribe.Project.to_tabular` for generating a ``pandas``-ready format:
+:py:meth:`lazyscribe.project.Project.to_tabular` for generating a ``pandas``-ready format:
 
 .. code-block:: python
 

--- a/docs/how-to/tag.rst
+++ b/docs/how-to/tag.rst
@@ -1,8 +1,8 @@
 Tag experiments
-==========================
+===============
 
 In this guide, we will discuss how you can add tags to your experiment. First,
-let's create a :py:class:`lazyscribe.Project`.
+let's create a :py:class:`lazyscribe.project.Project`.
 
 .. code-block:: python
 
@@ -10,7 +10,7 @@ let's create a :py:class:`lazyscribe.Project`.
 
     project = Project(fpath="project.json", mode="w")
 
-Then, while logging an experiment, we can add our tag using :py:meth:`lazyscribe.Experiment.tag`:
+Then, while logging an experiment, we can add our tag using :py:meth:`lazyscribe.experiment.Experiment.tag`:
 
 .. code-block:: python
 
@@ -38,10 +38,10 @@ or through multiple calls.
         if metric > 0.75:
             exp.tag("best-model")
 
-When you call :py:meth:`lazyscribe.Experiment.tag`, you can use ``overwrite=True`` to overwrite
+When you call :py:meth:`lazyscribe.experiment.Experiment.tag`, you can use ``overwrite=True`` to overwrite
 any existing tags.
 
 .. important::
 
-    If you call :py:meth:`lazyscribe.Experiment.tag` with no supplied tags and ``overwrite=True``, you
+    If you call :py:meth:`lazyscribe.experiment.Experiment.tag` with no supplied tags and ``overwrite=True``, you
     will delete all existing tags on the experiment.

--- a/docs/how-to/tests.rst
+++ b/docs/how-to/tests.rst
@@ -2,7 +2,7 @@ Log non-global metrics
 ======================
 
 Sometimes, it's helpful to log non-global metrics to an experimenent. To do so, create a
-:py:class:`lazyscribe.Test` using :py:meth:`lazyscribe.Experiment.log_test`:
+:py:class:`lazyscribe.test.Test` using :py:meth:`lazyscribe.experiment.Experiment.log_test`:
 
 .. code-block:: python
 
@@ -17,9 +17,9 @@ Sometimes, it's helpful to log non-global metrics to an experimenent. To do so, 
 
 The test's parameter has been also stored here.
 
-The :py:meth:`Experiment.log_test` context handler creates a :py:class:`Test` object and
+The :py:meth:`lazyscribe.experiment.Experiment.log_test` context handler creates a :py:class:`lazyscribe.test.Test` object and
 logs it back to the experiment when the handler exits. If you want to avoid using the context
-handler, instantiate your own test and append it to the ``tests`` list:
+handler, instantiate your own test and append it to the :py:attr:`lazyscribe.experiment.Experiment.tests` list:
 
 .. code-block:: python
 

--- a/docs/how-to/version-artifacts.rst
+++ b/docs/how-to/version-artifacts.rst
@@ -1,19 +1,19 @@
 Version artifacts
 =================
 
-This guide will walk you through the process of using :py:class:`lazyscribe.Repository`
+This guide will walk you through the process of using :py:class:`lazyscribe.repository.Repository`
 to access and version artifacts across projects.
 
-    A :py:class:`lazyscribe.Repository` is an organized structure that stores and versions
+    A :py:class:`lazyscribe.repository.Repository` is an organized structure that stores and versions
     your artifacts.
 
 Using a repository as a standalone structure
 --------------------------------------------
 
 If you have artifacts and/or objects that were generated outside of the ``lazyscribe`` ecosystem,
-you can still use them with the :py:class:`lazyscribe.Repository` structure. Similar to the guide
+you can still use them with the :py:class:`lazyscribe.repository.Repository` structure. Similar to the guide
 on :doc:`saving artifacts with experiments <artifact>`, we will use
-:py:meth:`lazyscribe.Repository.log_artifact`:
+:py:meth:`lazyscribe.repository.Repository.log_artifact`:
 
 .. code-block:: python
 
@@ -24,10 +24,10 @@ on :doc:`saving artifacts with experiments <artifact>`, we will use
 
     repository.save()
 
-After :py:meth:`lazyscribe.Repository.log_artifact`, the value ``[0, 1, 2]`` will be associated
+After :py:meth:`lazyscribe.repository.Repository.log_artifact`, the value ``[0, 1, 2]`` will be associated
 with the repository. However, it won't appear as a JSON file until you call
-:py:meth:`lazyscribe.Repository.save`. You can retrieve the artifact using
-:py:meth:`lazyscribe.Repository.load_artifact`:
+:py:meth:`lazyscribe.repository.Repository.save`. You can retrieve the artifact using
+:py:meth:`lazyscribe.repository.Repository.load_artifact`:
 
 .. code-block:: python
 
@@ -78,7 +78,7 @@ Promote artifacts from experiments to the repository
 Model experimentation is meant to be ephemeral. The Repository provides us with a structure to deploy
 and track versions of artifacts over time. So, how do these systems interact?
 
-We can use :py:meth:`lazyscribe.Experiment.promote_artifact` to associate an artifact with a repository.
+We can use :py:meth:`lazyscribe.experiment.Experiment.promote_artifact` to associate an artifact with a repository.
 The notion is that you may want to deploy/version the artifacts from the most successful experiment in
 a project. Here's how you use it.
 
@@ -105,13 +105,13 @@ Now, let's reload that project and promote the artifact to the repository:
 
     project["my-experiment"].promote_artifact(repository, "features")
 
-If you are calling :py:meth:`lazyscribe.Experiment.promote_artifact` after re-loading a project,
+If you are calling :py:meth:`lazyscribe.experiment.Experiment.promote_artifact` after re-loading a project,
 the method
 
 #. copies the artifact from the experiment filesystem location to the repository filesystem location, and
-#. calls :py:meth:`lazyscribe.Repository.save` to ensure ``repository.json`` is "in sync" with the filesystem.
+#. calls :py:meth:`lazyscribe.repository.Repository.save` to ensure ``repository.json`` is "in sync" with the filesystem.
 
-If you log the artifact to an experiment and call :py:meth:`lazyscribe.Experiment.promote_artifact` *before*
-calling :py:meth:`lazyscribe.Project.save`, it will behave exactly as if you called
-:py:meth:`lazyscribe.Repository.log_artifact` -- *you* will be responsible for calling
-:py:meth:`lazyscribe.Repository.save`.
+If you log the artifact to an experiment and call :py:meth:`lazyscribe.experiment.Experiment.promote_artifact` *before*
+calling :py:meth:`lazyscribe.project.Project.save`, it will behave exactly as if you called
+:py:meth:`lazyscribe.repository.Repository.log_artifact` -- *you* will be responsible for calling
+:py:meth:`lazyscribe.repository.Repository.save`.

--- a/lazyscribe/__init__.py
+++ b/lazyscribe/__init__.py
@@ -1,4 +1,4 @@
-"""Import path."""
+"""Main module."""
 
 from lazyscribe._meta import __version__  # noqa: F401
 from lazyscribe.experiment import Experiment

--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -9,16 +9,16 @@ from attrs import Attribute, asdict, fields, filters
 from lazyscribe.artifacts.base import Artifact
 
 
-def serializer(inst: type, field: Attribute, value: Any) -> Any:
+def serializer(inst: type, field: "Attribute[Any]", value: Any) -> Any:
     """Datetime and dependencies converter for :meth:`attrs.asdict`.
 
     Parameters
     ----------
-    inst
+    inst : type
         Included for compatibility.
-    field
+    field : attrs.Attribute[Any]
         The field name.
-    value
+    value : Any
         The field value.
 
     Returns
@@ -42,6 +42,7 @@ def serializer(inst: type, field: Attribute, value: Any) -> Any:
 
 
 def serialize_artifacts(alist: list[Artifact]) -> Iterator[dict[str, Any]]:
+    """Serialize list of artifacts."""
     yield from (
         {
             **asdict(
@@ -68,7 +69,7 @@ def utcnow() -> datetime:
 
     Returns
     -------
-    datetime
+    datetime.datetime
         Now in UTC, without timezone info.
     """
     return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/lazyscribe/artifacts/__init__.py
+++ b/lazyscribe/artifacts/__init__.py
@@ -20,9 +20,8 @@ def _get_handler(alias: str) -> type[Artifact]:
 
     Returns
     -------
-    Artifact
-        The artifact handler class object. This object will need to be constructed
-        using :py:meth:`lazyscribe.artifacts.Artifact.construct`.
+    type[lazyscribe.artifacts.base.Artifact]
+        The artifact handler class.
     """
     entry = entry_points(group="lazyscribe.artifact_type")
 

--- a/lazyscribe/artifacts/base.py
+++ b/lazyscribe/artifacts/base.py
@@ -16,21 +16,22 @@ class Artifact(metaclass=ABCMeta):
 
     Artifact handlers are not meant to be initialized directly.
 
-    Class Attributes
-    ----------------
+    Attributes
+    ----------
     alias : str
         The alias for the artifact handler. This value will be supplied to
         :py:meth:`lazyscribe.experiment.Experiment.log_artifact`.
+        (A class attribute.)
     suffix : str
         The standard suffix for the files written and read by this handler.
+        (A class attribute.)
     binary : bool
         Whether or not the file format for the handler is binary in nature. This
         affects whether or not the file handler uses ``w`` or ``wb``.
+        (A class attribute.)
     output_only : bool
         Whether or not the file output by the handler is meant to be read as the orginal project.
-
-    Attributes
-    ----------
+        (A class attribute.)
     name : str
         The name of the artifact.
     fname : str

--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -33,21 +33,16 @@ class JoblibArtifact(Artifact):
         This class is not meant to be initialized directly. Please use the ``construct``
         method.
 
-    Class Attributes
-    ----------------
-    See also "Class Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+    .. note::
 
+        For the attributes documentation, see also "Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+
+    Attributes
+    ----------
     alias : str = "json"
     suffix : str = "json"
     binary : bool = False
     output_only : bool = False
-
-    Attributes
-    ----------
-    :cvar alias : str = "json"
-    :cvar suffix : str = "json"
-    :cvar binary : bool = False
-    :cvar output_only : bool = False
 
     package : str
         The root module name of the Python object to be serialized.

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -24,21 +24,16 @@ class JSONArtifact(Artifact):
         This class is not meant to be initialized directly. Please use the ``construct``
         method.
 
-    Class Attributes
-    ----------------
-    See also "Class Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+    .. note::
 
+        For the attributes documentation, see also "Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+
+    Attributes
+    ----------
     alias : str = "json"
     suffix : str = "json"
     binary : bool = False
     output_only : bool = False
-
-    Attributes
-    ----------
-    :cvar alias : str = "json"
-    :cvar suffix : str = "json"
-    :cvar binary : bool = False
-    :cvar output_only : bool = False
 
     python_version : str
         Minor Python version (e.g. ``"3.10"``).

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime
+from io import IOBase
 from json import dump, load
 from typing import Any, ClassVar
 
@@ -22,6 +23,25 @@ class JSONArtifact(Artifact):
 
         This class is not meant to be initialized directly. Please use the ``construct``
         method.
+
+    Class Attributes
+    ----------------
+    See also "Class Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+
+    alias : str = "json"
+    suffix : str = "json"
+    binary : bool = False
+    output_only : bool = False
+
+    Attributes
+    ----------
+    :cvar alias : str = "json"
+    :cvar suffix : str = "json"
+    :cvar binary : bool = False
+    :cvar output_only : bool = False
+
+    python_version : str
+        Minor Python version (e.g. ``"3.10"``).
     """
 
     alias: ClassVar[str] = "json"
@@ -37,26 +57,26 @@ class JSONArtifact(Artifact):
         value: Any = None,
         fname: str | None = None,
         created_at: datetime | None = None,
-        writer_kwargs: dict | None = None,
+        writer_kwargs: dict[str, Any] | None = None,
         version: int = 0,
         dirty: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> JSONArtifact:
         """Construct the handler class.
 
         Parameters
         ----------
         name : str
             The name of the artifact.
-        value : object, optional (default None)
+        value : Any, optional (default None)
             The value for the artifact. The default value of ``None`` is used when
             an experiment is loaded from the project JSON.
         fname : str, optional (default None)
-            The filename of the artifact. If not provided, this value will be derived from
+            The filename for the artifact. If set to ``None`` or not provided, it will be derived from
             the name of the artifact and the suffix for the class.
-        created_at : datetime, optional (default None)
-            When the artifact was created. If not supplied, :py:meth:`datetime.now` will be used.
-        writer_kwargs : dict, optional (default None)
+        created_at : datetime.datetime, optional (default ``lazyscribe._utils.utcnow()``)
+            When the artifact was created.
+        writer_kwargs : dict[str, Any], optional (default {})
             Keyword arguments for writing an artifact to the filesystem. Provided when an artifact
             is logged to an experiment.
         version : int, optional (default 0)
@@ -65,9 +85,13 @@ class JSONArtifact(Artifact):
             Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
             or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
             on whether the artifact is new or has been updated.
-        **kwargs : dict
-            Other keyword arguments.
-            Usually class attributes obtained from a project JSON.
+        python_version : str, optional
+            Minor Python version (e.g. ``"3.10"``).
+
+        Returns
+        -------
+        JSONArtifact
+            The artifact.
         """
         python_version = kwargs.get("python_version") or ".".join(
             str(i) for i in sys.version_info[:2]
@@ -76,24 +100,24 @@ class JSONArtifact(Artifact):
         return cls(
             name=name,
             value=value,
-            writer_kwargs=writer_kwargs or {},
             fname=fname
             or f"{slugify(name)}-{slugify(created_at.strftime('%Y%m%d%H%M%S'))}.{cls.suffix}",
             created_at=created_at,
-            python_version=python_version,
+            writer_kwargs=writer_kwargs or {},
             version=version,
             dirty=dirty,
+            python_version=python_version,
         )
 
     @classmethod
-    def read(cls, buf, **kwargs):
+    def read(cls, buf: IOBase, **kwargs: Any) -> Any:
         """Read in the JSON file.
 
         Parameters
         ----------
         buf : file-like object
             The buffer from a ``fsspec`` filesystem.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for :py:meth:`json.load`
 
         Returns
@@ -104,7 +128,7 @@ class JSONArtifact(Artifact):
         return load(buf, **kwargs)
 
     @classmethod
-    def write(cls, obj, buf, **kwargs):
+    def write(cls, obj: Any, buf: IOBase, **kwargs: Any) -> None:
         """Write the content to a JSON file.
 
         Parameters
@@ -113,7 +137,7 @@ class JSONArtifact(Artifact):
             The JSON-serializable object.
         buf : file-like object
             The buffer from a ``fsspec`` filesystem.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for :py:meth:`json.dump`.
         """
         dump(obj, buf, **kwargs)

--- a/lazyscribe/artifacts/yaml.py
+++ b/lazyscribe/artifacts/yaml.py
@@ -32,18 +32,16 @@ class YAMLArtifact(Artifact):
         This class is not meant to be initialized directly. Please use the ``construct``
         method.
 
-    Class Attributes
-    ----------------
-    See also "Class Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+    .. note::
 
+        For the attributes documentation, see also "Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
+
+    Attributes
+    ----------
     alias : str = "yaml"
     suffix : str = "yaml"
     binary : bool = False
     output_only : bool = False
-
-    Attributes
-    ----------
-    See also "Attributes" of :py:class:`lazyscribe.artifacts.base.Artifact`.
     """
 
     alias: ClassVar[str] = "yaml"

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -1,5 +1,7 @@
 """Experiment dataclass."""
 
+from __future__ import annotations
+
 import getpass
 import inspect
 import json
@@ -11,7 +13,7 @@ from contextlib import contextmanager
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 from attrs import Factory, asdict, define, evolve, field, fields, filters, frozen
 from fsspec.implementations.local import LocalFileSystem
@@ -19,10 +21,11 @@ from fsspec.spec import AbstractFileSystem
 from slugify import slugify
 
 from lazyscribe._utils import serializer, utcnow
-from lazyscribe.artifacts import Artifact, _get_handler
+from lazyscribe.artifacts import _get_handler
+from lazyscribe.artifacts.base import Artifact
 from lazyscribe.exception import ArtifactLoadError, ArtifactLogError, SaveError
 from lazyscribe.repository import Repository
-from lazyscribe.test import ReadOnlyTest, Test
+from lazyscribe.test import Test
 
 LOG = logging.getLogger(__name__)
 
@@ -38,22 +41,41 @@ class Experiment:
     ----------
     name : str
         The name of the experiment.
-    project : Path
+    project : pathlib.Path
         The path to the project JSON associated with the project.
+    dir : pathlib.Path, optional (default None)
+        Directory for the project and the experiment. If not supplied, the parent directory for the ``project`` file
+        will be used.
     author : str, optional (default ``getpass.getuser()``)
         The author of the experiment.
-    metrics : dict, optional (default {})
+    last_updated_by : str, optional (default None)
+        Last editor of the experiment. If not supplied, the ``author`` will be used.
+    metrics : dict[str, float | int], optional (default {})
         A dictionary of metric values. Each metric value can be an individual value or a list.
-    parameters : dict, optional (default {})
+    parameters : dict[str, Any], optional (default {})
         A dictionary of experiment parameters. The key must be a string but the value can be
         anything.
-    created_at : datetime, optional (default ``utcnow()``)
-        When the experiment was created.
-    last_updated : datetime, optional (default ``utcnow()``)
-        When the experiment was last updated.
-    dependencies : dict, optional (default None)
+    created_at : datetime.datetime, optional (default ``lazyscribe._utils.utcnow()``)
+        When the experiment was created (in UTC).
+    last_updated : datetime.datetime, optional (default ``lazyscribe._utils.utcnow()``)
+        When the experiment was last updated (in UTC).
+    short_slug : str, optional (default None)
+        Slugified ``name``. Defaults to calling :py:meth:`slugify.slugify` on the ``name`` attribute.
+    slug : str, optional (default None)
+        Unique identifier for the experiment. Deafults to the slugified ``name`` with the creation date
+        appended in the format ``YYYYMMDDHHMMSS``.
+    tags : list[str], optional (default [])
+        Tags for filtering and identifying experiments across a project.
+    dependencies : dict[str, lazyscribe.experiment.Experiment], optional (default {})
         A dictionary of upstream project experiments. The key is the short slug for the upstream
-        experiment and the value is an :class:`Experiment` instance.
+        experiment and the value is an :py:class:`Experiment` instance.
+    tests : list[lazyscribe.test.Test], optional (default [])
+        List of :py:class:`lazyscribe.test.Test` objects corresponding to sub-population/non-global metrics.
+    artifacts : list[lazyscribe.artifacts.base.Artifact], optional (default [])
+        List of :py:class:`lazyscribe.artifact.base.Artifact` objects corresponding to experimental artifacts.
+    dirty : bool, optional (default True)
+        Whether or not this experiment should be saved when :py:meth:`lazyscribe.project.Project.save`
+        is called. This decision is based on whether the experiment is new or has been updated.
     """
 
     name: str = field()
@@ -62,25 +84,25 @@ class Experiment:
     fs: AbstractFileSystem = field(eq=False)
     author: str = Factory(getpass.getuser)
     last_updated_by: str = field()
-    metrics: dict = Factory(lambda: {})
-    parameters: dict = Factory(lambda: {})
+    metrics: dict[str, float | int] = Factory(lambda: {})
+    parameters: dict[str, Any] = Factory(lambda: {})
     created_at: datetime = Factory(utcnow)
     last_updated: datetime = Factory(utcnow)
-    dependencies: dict = field(eq=False, factory=lambda: {})
+    dependencies: dict[str, Experiment] = field(eq=False, factory=lambda: {})
     short_slug: str = field()
     slug: str = field()
-    tests: list[Union[Test, ReadOnlyTest]] = Factory(lambda: [])
+    tests: list[Test] = Factory(lambda: [])
     artifacts: list[Artifact] = Factory(factory=lambda: [])
     tags: list[str] = Factory(factory=lambda: [])
     dirty: bool = field(eq=False, factory=lambda: True)
 
     @dir.default
     def _dir_factory(self) -> Path:
-        """Get the default directory for the project and experiment.
+        """Get the default directory for the project and the experiment.
 
         Returns
         -------
-        Path
+        pathlib.Path
             Absolute path to the directory.
         """
         return self.project.parent
@@ -91,7 +113,7 @@ class Experiment:
 
         Returns
         -------
-        LocalFileSystem
+        fsspec.implementations.local.LocalFileSystem
             A standard local filesystem through ``fsspec``.
         """
         return LocalFileSystem()
@@ -119,7 +141,7 @@ class Experiment:
         Returns
         -------
         str
-            Experiment slug, in the format `{name}-{created_at}-{author}`.
+            Experiment slug, in the format `{name}-{created_at}`.
         """
         return slugify(f"{self.name}-{self.created_at.strftime('%Y%m%d%H%M%S')}")
 
@@ -132,12 +154,12 @@ class Experiment:
 
         Returns
         -------
-        Path
+        pathlib.Path
             The path for the experiment.
         """
         return self.dir / self.slug
 
-    def log_metric(self, name: str, value: Union[float, int]):
+    def log_metric(self, name: str, value: float | int) -> None:
         """Log a metric to the experiment.
 
         This method will overwrite existing keys.
@@ -146,7 +168,7 @@ class Experiment:
         ----------
         name : str
             Name of the metric.
-        value : int or float
+        value : int | float
             Value of the metric.
         """
         self.last_updated = utcnow()
@@ -154,7 +176,7 @@ class Experiment:
 
         self.dirty = True
 
-    def log_parameter(self, name: str, value: Any):
+    def log_parameter(self, name: str, value: Any) -> None:
         """Log a parameter to the experiment.
 
         This method will overwrite existing keys.
@@ -171,7 +193,7 @@ class Experiment:
 
         self.dirty = True
 
-    def tag(self, *args, overwrite: bool = False):
+    def tag(self, *args: str, overwrite: bool = False) -> None:
         """Add one or more tags to the experiment.
 
         .. important::
@@ -201,10 +223,10 @@ class Experiment:
         name: str,
         value: Any,
         handler: str,
-        fname: Optional[str] = None,
+        fname: str | None = None,
         overwrite: bool = False,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Log an artifact to the experiment.
 
         This method associates an artifact with the experiment, but the artifact will
@@ -224,12 +246,12 @@ class Experiment:
         overwrite : bool, optional (default False)
             Whether or not to overwrite an existing artifact with the same name. If set to ``True``,
             the previous artifact will be removed and overwritten with the current artifact.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for the write function of the handler.
 
         Raises
         ------
-        ArtifactLogError
+        lazyscribe.exception.ArtifactLogError
             Raised if an artifact is supplied with the same name as an existing artifact and
             ``overwrite`` is set to ``False``.
         """
@@ -269,7 +291,7 @@ class Experiment:
                     stacklevel=2,
                 )
 
-    def load_artifact(self, name: str, validate: bool = True, **kwargs) -> Any:
+    def load_artifact(self, name: str, validate: bool = True, **kwargs: Any) -> Any:
         """Load a single artifact.
 
         Parameters
@@ -279,30 +301,30 @@ class Experiment:
         validate : bool, optional (default True)
             Whether or not to validate the runtime environment against the artifact
             metadata.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for the handler read function.
 
         Returns
         -------
-        object
-            The artifact.
+        Any
+            The artifact object.
 
         Raises
         ------
-        ArtifactLoadError
+        lazyscribe.exception.ArtifactLoadError
             If ``validate`` and runtime environment does not match artifact metadata.
             Or if there is no artifact found with the name provided.
         """
         for artifact in self.artifacts:
             if artifact.name == name:
                 # Construct the handler with relevant parameters.
-                artifact_attrs = {
+                artifact_attrs: dict[str, Any] = {
                     x: y
                     for x, y in inspect.getmembers(artifact)
                     if not x.startswith("_") and not inspect.ismethod(y)
                 }
-                exclude_params = ["value", "fname", "created_at", "dirty"]
-                construct_params = [
+                exclude_params: list[str] = ["value", "fname", "created_at", "dirty"]
+                construct_params: list[str] = [
                     param
                     for param in inspect.signature(artifact.construct).parameters
                     if param not in exclude_params
@@ -347,7 +369,7 @@ class Experiment:
         return out
 
     @contextmanager
-    def log_test(self, name: str, description: Optional[str] = None) -> Iterator[Test]:
+    def log_test(self, name: str, description: str | None = None) -> Iterator[Test]:
         """Add a test to the experiment using a context handler.
 
         A test is a specific location for non-global metrics.
@@ -361,7 +383,7 @@ class Experiment:
 
         Yields
         ------
-        Test
+        lazyscribe.test.Test
             The :py:class:`lazyscribe.test.Test` dataclass.
         """
         test = Test(name=name, description=description)
@@ -373,12 +395,12 @@ class Experiment:
 
         self.dirty = True
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the experiment to a dictionary.
 
         Returns
         -------
-        dict
+        dict[str, Any]
             The experiment dictionary.
         """
         return asdict(
@@ -392,7 +414,7 @@ class Experiment:
             ),
         )
 
-    def to_tabular(self) -> dict:
+    def to_tabular(self) -> dict[tuple[str] | tuple[str, str], Any]:
         """Create a dictionary that can be fed into ``pandas``.
 
         Returns
@@ -441,7 +463,7 @@ class Experiment:
             **{("metrics", key): value for key, value in d["metrics"].items()},
         }
 
-    def promote_artifact(self, repository: Repository, name: str):
+    def promote_artifact(self, repository: Repository, name: str) -> None:
         """Associate an artifact with a :py:class:`lazyscribe.repository.Repository`.
 
         The purpose of this method is to move an artifact from an *ephemeral*
@@ -455,23 +477,24 @@ class Experiment:
 
         Parameters
         ----------
-        repository : Repository
+        repository : lazyscribe.repository.Repository
             The :py:class:`lazyscribe.repository.Repository` to promote the artifact to.
         name : str
             The artifact to promote.
 
         Raises
         ------
-        ArtifactLogError
+        lazyscribe.exception.ArtifactLogError
             Raised if the artifact to be promoted is not newer than the latest version available
             in the repository.
-
             Raised if
 
             * the artifact ``name`` exists on the filesystem, and
             * the filesystem protocol does not match between the repository and the experiment.
-        ArtifactLoadError
+        lazyscribe.exception.ArtifactLoadError
             Raised if there is no artifact with the name ``name`` in the experiment.
+        lazyscribe.exception.SaveError
+            Raised when writing to the filesystem fails.
         """
         for artifact in self.artifacts:
             if artifact.name == name:
@@ -527,11 +550,11 @@ class Experiment:
         else:
             raise ArtifactLoadError(f"No artifact with name {name}")
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Shortened string representation."""
         return f"<lazyscribe.experiment.Experiment at {hex(id(self))}>"
 
-    def __gt__(self, other):
+    def __gt__(self, other: Experiment) -> bool:
         """Determine whether this experiment is newer than another experiment.
 
         If the experiments have the same ``slug``, this function will compare using the
@@ -543,7 +566,7 @@ class Experiment:
         else:
             return self.created_at > other.created_at
 
-    def __lt__(self, other):
+    def __lt__(self, other: Experiment) -> bool:
         """Determine whether this experiment is older than another experiment.
 
         If the experiments have the same ``slug``, this function will compare using the
@@ -555,7 +578,7 @@ class Experiment:
         else:
             return self.created_at < other.created_at
 
-    def __ge__(self, other):
+    def __ge__(self, other: Experiment) -> bool:
         """Determine whether this experiment is newer than another experiment.
 
         If the experiments have the same ``slug``, this function will compare using the
@@ -564,7 +587,7 @@ class Experiment:
         """
         return bool(self == other or self > other)
 
-    def __le__(self, other):
+    def __le__(self, other: Experiment) -> bool:
         """Determine whether this experiment is older than another experiment.
 
         If the experiments have the same ``slug``, this function will compare using the
@@ -578,6 +601,6 @@ class Experiment:
 class ReadOnlyExperiment(Experiment):
     """Immutable version of an experiment."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Shortened string representation."""
         return f"<lazyscribe.experiment.ReadOnlyExperiment at {hex(id(self))}>"

--- a/lazyscribe/linked.py
+++ b/lazyscribe/linked.py
@@ -17,24 +17,24 @@ class Node:
 
     Parameters
     ----------
-    data : any, optional (default None)
+    data : Any, optional (default None)
         The current data.
-    next : any, optional (default None)
+    next : Node | None, optional (default None)
         The next data in the chain.
     """
 
     data: Any = None
-    next: Any = None
+    next: Node | None = None
 
-    def to_list(self) -> list:
+    def to_list(self) -> list[Any]:
         """Convert the nodes to a de-duped list.
 
         Returns
         -------
-        list
-            A standard list.
+        list[Any]
+            A standard list of data.
         """
-        out = []
+        out: list[Any] = []
         while self.next:
             out.append(self.data)
             self = self.next
@@ -49,13 +49,13 @@ class LinkedList:
 
     Parameters
     ----------
-    head : any, optional (default None)
+    head : Node, optional (default None)
         The start of the list.
     """
 
-    head: Any = None
+    head: Node | None = None
 
-    def append(self, data: Any):
+    def append(self, data: Any) -> None:
         """Append a new node to the end of the list.
 
         Parameters
@@ -74,7 +74,7 @@ class LinkedList:
             self.head = new
 
     @staticmethod
-    def from_list(data: list) -> LinkedList:
+    def from_list(data: list[Any]) -> LinkedList:
         """Convert a standard list to a linked list."""
         # Sort the list
         sorted_list = sorted(data)
@@ -85,7 +85,7 @@ class LinkedList:
         return out
 
 
-def merge(list1: Node, list2: Node) -> Any:
+def merge(list1: Node, list2: Node) -> Node:
     """Merge two linked lists.
 
     Parameters
@@ -102,18 +102,19 @@ def merge(list1: Node, list2: Node) -> Any:
     """
     # Create the head of the new list as a dummy node
     head = Node()
-    temp = head
-    # Loop while some data exists in the latest node
-    while list1 or list2:
+    current = head
+    # Loop while the data exists
+    while list1 and list2:
         # Add the earliest available node from either l1 or l2
-        if list1 and (not list2 or list1.data < list2.data):
-            temp.next = Node(list1.data)
+        if list1.data < list2.data:
+            current.next = list1
             # Scroll the list
-            list1 = list1.next
+            list1: Node | None = list1.next  # type: ignore[no-redef]
         else:
-            temp.next = Node(list2.data)
+            current.next = list2
             # Scroll the list
-            list2 = list2.next
-        temp = temp.next
-
-    return head.next
+            list2: Node | None = list2.next  # type: ignore[no-redef]
+        current = current.next
+    # Add non-empty list
+    current.next = list1 or list2
+    return head.next  # type: ignore[return-value]

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -34,16 +34,24 @@ class Repository:
     mode : {"r", "a", "w", "w+"}, optional (default "w")
         The mode for opening the repository.
 
-        * ``r``: No new artifacts can be logged.
+        * ``r``: All artifacts will be loaded. No new artifacts can be logged.
         * ``a``: The same as ``w+`` (deprecated).
-        * ``w``: No existing artifacts will be loaded.
-        * ``w+``: All artifacts will be loaded.
+        * ``w``: No existing artifacts will be loaded. Artifacts can be added.
+        * ``w+``: All artifacts will be loaded. New artifacts can be added.
+    **storage_options
+        Storage options to pass to the filesystem initialization. Will be passed to
+        :py:meth:`fsspec.filesystem`.
 
     Attributes
     ----------
-    artifacts : list[Artifact]
+    artifacts : list[lazyscribe.artifact.Artifact]
         The list of artifacts in the repository.
     """
+
+    fpath: Path
+    mode: Literal["r", "a", "w", "w+"]  # TODO: remove `mode="a"` in version 2.0
+    storage_options: dict[str, Any]
+    artifacts: list[Artifact]
 
     def __init__(
         self,
@@ -51,9 +59,15 @@ class Repository:
         mode: Literal[
             "r", "a", "w", "w+"
         ] = "w",  # TODO: remove `mode="a"` in version 2.0
-        **storage_options,
-    ):
-        """Init method."""
+        **storage_options: Any,
+    ) -> None:
+        """Init method.
+
+        Raises
+        ------
+        ValueError
+            Raised on invalid ``mode`` value.
+        """
         if isinstance(fpath, str):
             parsed = urlparse(fpath)
             self.fpath = Path(parsed.netloc + parsed.path)
@@ -80,12 +94,12 @@ class Repository:
         if mode in ("r", "w+") and self.fs.isfile(str(self.fpath)):
             self.load()
 
-    def load(self):
+    def load(self) -> None:
         """Load existing artifacts."""
         with self.fs.open(str(self.fpath), "r") as infile:
             data = json.load(infile)
 
-        artifacts = []
+        artifacts: list[Artifact] = []
         for artifact in data:
             handler_cls = _get_handler(artifact.pop("handler"))
             created_at = datetime.fromisoformat(artifact.pop("created_at"))
@@ -100,12 +114,12 @@ class Repository:
         value: Any,
         handler: str,
         fname: str | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Log an artifact to the repository.
 
         This method associates an artifact with the repository, but the artifact will
-        not be written until :py:meth:`lazyscribe.Repository.save` is called.
+        not be written until :py:meth:`lazyscribe.repository.Repository.save` is called.
 
         Parameters
         ----------
@@ -118,19 +132,21 @@ class Repository:
         fname : str, optional (default None)
             The filename for the artifact. If set to ``None`` or not provided, it will be derived
             from the name of the artifact and the builtin suffix for each handler.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for the write function of the handler.
 
         Raises
         ------
-        ReadOnlyError
+        lazyscribe.exception.ReadOnlyError
             If repository is in read-only mode.
         """
         if self.mode == "r":
             raise ReadOnlyError("Repository is in read-only mode.")
         # Retrieve and construct the handler
         self.last_updated = utcnow()
-        artifacts_matching_name = [art for art in self.artifacts if art.name == name]
+        artifacts_matching_name: list[Artifact] = [
+            art for art in self.artifacts if art.name == name
+        ]
         version = (
             max(art.version for art in artifacts_matching_name) + 1
             if artifacts_matching_name
@@ -159,7 +175,7 @@ class Repository:
         validate: bool = True,
         version: datetime | str | int | None = None,
         match: Literal["asof", "exact"] = "exact",
-        **kwargs,
+        **kwargs: Any,
     ) -> Any:
         """Load a single artifact.
 
@@ -176,31 +192,39 @@ class Repository:
             a string corresponding to the ``created_at`` field in the format ``"%Y-%m-%dT%H:%M:%S"``
             (e.g. ``"2025-01-25T12:36:22"``), or an integer version.
             If set to ``None`` or not provided, defaults to the most recent version.
-        match : "asof" | "exact", optional (default "exact")
+        match : {"asof", "exact"}, optional (default "exact")
             Matching logic. Only relevant for ``str`` and ``datetime.datetime`` values for
             ``version``. ``exact`` will provide an artifact with the exact ``created_at``
             value provided. ``asof`` will provide the most recent version as of the
             ``version`` value.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for the handler read function.
 
         Returns
         -------
         Any
             The artifact object.
+
+        Raises
+        ------
+        ValueError
+            Raised on invalid ``match`` value.
+            Raised if no valid artifact was found.
+        lazyscribe.exception.ArtifactLoadError
+            Raised if ``validate`` and runtime environment does not match artifact metadata.
         """
         # Search for the artifact
         artifact = self._search_artifact_versions(
             name=name, version=version, match=match
         )
         # Construct the handler with relevant parameters.
-        artifact_attrs = {
+        artifact_attrs: dict[str, Any] = {
             x: y
             for x, y in inspect.getmembers(artifact)
             if not x.startswith("_") and not inspect.ismethod(y)
         }
-        exclude_params = ["value", "fname", "created_at", "dirty"]
-        construct_params = [
+        exclude_params: list[str] = ["value", "fname", "created_at", "dirty"]
+        construct_params: list[str] = [
             param
             for param in inspect.signature(artifact.construct).parameters
             if param not in exclude_params
@@ -259,7 +283,7 @@ class Repository:
             a string corresponding to the ``created_at`` field in the format ``"%Y-%m-%dT%H:%M:%S"``
             (e.g. ``"2025-01-25T12:36:22"``), or an integer version.
             If set to ``None`` or not provided, defaults to the most recent version.
-        match : "asof" | "exact", optional (default "exact")
+        match : {"asof", "exact"}, optional (default "exact")
             Matching logic. Only relevant for ``str`` and ``datetime.datetime`` values for
             ``version``. ``exact`` will provide an artifact with the exact ``created_at``
             value provided. ``asof`` will provide the most recent version as of the
@@ -267,21 +291,31 @@ class Repository:
 
         Returns
         -------
-        dict
+        dict[str, Any]
             The artifact metadata.
+
+        Raises
+        ------
+        ValueError
+            Raised on invalid ``match`` value.
+            Raised if no valid artifact was found.
         """
-        artifact = self._search_artifact_versions(name, version, match)
+        artifact = self._search_artifact_versions(
+            name=name, version=version, match=match
+        )
 
         return next(serialize_artifacts([artifact]))
 
-    def save(self):
+    def save(self) -> None:
         """Save the repository data.
 
         This includes saving any artifact data.
 
         Raises
         ------
-        SaveError
+        lazyscribe.exception.ReadOnlyError
+            Raised when trying to save when the project is in read-only mode.
+        lazyscribe.exception.SaveError
             Raised when writing to the filesystem fails.
         """
         if self.mode == "r":
@@ -346,23 +380,29 @@ class Repository:
             a string corresponding to the ``created_at`` field in the format ``"%Y-%m-%dT%H:%M:%S"``
             (e.g. ``"2025-01-25T12:36:22"``), or an integer version.
             If set to ``None`` or not provided, defaults to the most recent version.
-        match : "asof" | "exact", optional (default "exact")
+        match : {"asof", "exact"}, optional (default "exact")
             Matching logic. Only relevant for ``str`` and ``datetime.datetime`` values for
             ``version``. ``exact`` will provide an artifact with the exact ``created_at``
             value provided. ``asof`` will provide the most recent version as of the
             ``version`` value.
+
+        Raises
+        ------
+        ValueError
+            Raised on invalid ``match`` value.
+            Raised if no valid artifact was found.
         """
         artifacts_matching_name = sorted(
             [art for art in self.artifacts if art.name == name],
             key=lambda x: x.created_at,
         )
+        if not artifacts_matching_name:
+            raise ValueError(f"No artifact with name {name}")
         version = (
             datetime.strptime(version, "%Y-%m-%dT%H:%M:%S")
             if isinstance(version, str)
             else version
         )
-        if not artifacts_matching_name:
-            raise ValueError(f"No artifact with name {name}") from None
         if version is None:
             artifact = artifacts_matching_name[-1]
         elif isinstance(version, datetime):
@@ -399,7 +439,7 @@ class Repository:
             else:
                 raise ValueError(
                     "Please provide ``exact`` or ``asof`` as the value for ``match``"
-                ) from None
+                )
         else:
             try:
                 # Integer version is 0-indexed

--- a/lazyscribe/test.py
+++ b/lazyscribe/test.py
@@ -1,6 +1,8 @@
 """Sub-population tests."""
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from attrs import Factory, asdict, define, field, frozen
 
@@ -21,9 +23,9 @@ class Test:
         The name of the test.
     description : str, optional (default None)
         A description of the test.
-    metrics : dict, optional (default {})
+    metrics : dict[str, float | int], optional (default {})
         A dictionary of metric values. Each metric value can be an individual value or a list.
-    parameters : dict, optional (default {})
+    parameters : dict[str, Any], optional (default {})
         A dictionary of test parameters. The key must be a string but the value can be anything.
     """
 
@@ -31,11 +33,11 @@ class Test:
     __test__ = False
 
     name: str = field()
-    description: Optional[str] = Factory(lambda: None)
-    metrics: dict = Factory(lambda: {})
-    parameters: dict = Factory(lambda: {})
+    description: str | None = Factory(lambda: None)
+    metrics: dict[str, float | int] = Factory(lambda: {})
+    parameters: dict[str, Any] = Factory(lambda: {})
 
-    def log_metric(self, name: str, value: Union[float, int]):
+    def log_metric(self, name: str, value: float | int) -> None:
         """Log a metric to the test.
 
         This method will overwrite existing keys.
@@ -44,16 +46,16 @@ class Test:
         ----------
         name : str
             Name of the metric.
-        value : int or float
+        value : int | float
             Value of the metric.
         """
         self.metrics[name] = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Shortened string representation."""
         return f"<lazyscribe.test.Test at {hex(id(self))}>"
 
-    def log_parameter(self, name: str, value: Any):
+    def log_parameter(self, name: str, value: Any) -> None:
         """Log a parameter to the test.
 
         This method will overwrite existing keys.
@@ -62,17 +64,17 @@ class Test:
         ----------
         name : str
             The name of the parameter.
-        value : any
+        value : Any
             The parameter itself.
         """
         self.parameters[name] = value
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the test to a dictionary.
 
         Returns
         -------
-        dict
+        dict[str, Any]
             The test dictionary.
         """
         return asdict(
@@ -80,7 +82,7 @@ class Test:
             value_serializer=serializer,
         )
 
-    def to_tabular(self) -> dict:
+    def to_tabular(self) -> dict[tuple[str] | tuple[str, str], Any]:
         """Create a dictionary that can be fed into ``pandas``.
 
         Returns
@@ -119,6 +121,6 @@ class Test:
 class ReadOnlyTest(Test):
     """Immutable version of the test."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Shortened string representation."""
         return f"<lazyscribe.test.ReadOnlyTest at {hex(id(self))}>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,17 +105,23 @@ select = [
 	"TID252",  # flake8-tidy-imports ban relative imports
 	"SIM",  # flake8-simplify
 	"LOG",  # flake8-logging
-	"RUF",  # Ruff errors
+	"ANN",  # flake8-annotations
+	"RUF",  # Ruff errors,
 ]
 ignore = [
 	"C901",  # Function/method is too complex. (Add back in later.)
 	"E501",  # Line too long. Using formatter instead.
+	"ANN401",  # `Any` usage
 ]
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402"]
-"**/{tests,docs}/*" = ["E402", "D", "F841", "ARG"]
-"tutorials/*" = ["D", "T201"]
+"tests/**/*" = ["ANN"]
+"{tests,docs}/**/*" = ["E402"]
+"tutorials/*" = ["T201", "D205", "D400"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
@@ -127,8 +133,12 @@ convention = "numpy"
 
 [tool.mypy]
 python_version = 3.9
+exclude = [
+	'^docs\/',
+	'^lazyscribe\/prefect\/',
+	'^tests\/'
+]
+strict = true
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-allow_redefinition = true
-check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ command = "pytest tests"
 
 [tool.ruff]
 target-version = "py39"
+exclude = [
+	'docs/',
+	'lazyscribe/prefect/',
+	'tests/test_prefect.py'
+]
 
 [tool.ruff.lint]
 preview = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,24 @@
+"""Stubs for testing."""
+
 from __future__ import annotations
 
 from datetime import datetime
+from io import IOBase
 from typing import Any, ClassVar
 
 from attrs import field
 from slugify import slugify
 
 from lazyscribe._utils import utcnow
-from lazyscribe.artifacts import Artifact
+from lazyscribe.artifacts.base import Artifact
 
 
 class TestArtifact(Artifact):
+    """Stub for test artifacts."""
+
     # Tell pytest it's not a Python test class
     __test__ = False
+
     alias: ClassVar[str] = "testartifact"
     suffix: ClassVar[str] = "testartifact"
     binary: ClassVar[bool] = True
@@ -23,14 +29,15 @@ class TestArtifact(Artifact):
     def construct(
         cls,
         name: str,
-        value: Any | None = None,
+        value: Any = None,
         fname: str | None = None,
         created_at: datetime | None = None,
-        writer_kwargs: dict | None = None,
+        writer_kwargs: dict[str, Any] | None = None,
         version: int | None = None,
         dirty: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> TestArtifact:
+        """Stub for constructing."""
         created_at = created_at or utcnow()
         version = version if version is not None else 0
         return cls(
@@ -42,12 +49,13 @@ class TestArtifact(Artifact):
             created_at=created_at,
             version=version,
             dirty=dirty,
+            **kwargs,
         )
 
     @classmethod
-    def read(cls, buf, **kwargs):
-        pass
+    def read(cls, buf: IOBase, **kwargs: Any) -> Any:
+        """Stub for reading."""
 
     @classmethod
-    def write(cls, obj, buf, **kwargs):
-        pass
+    def write(cls, obj: Any, buf: IOBase, **kwargs: Any) -> None:
+        """Stub for writing."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -157,7 +157,7 @@ def test_joblib_handler(tmp_path):
 
     # Check that the handler correctly captures the environment variables
     assert (
-        JoblibArtifact(
+        JoblibArtifact.construct(
             name="EXCLUDED FROM COMPARISON",
             fname="EXCLUDED FROM COMPARISON",
             value=None,
@@ -166,7 +166,7 @@ def test_joblib_handler(tmp_path):
             package="sklearn",
             package_version=sklearn.__version__,
             joblib_version=joblib.__version__,
-            version=None,
+            version=0,
             dirty=False,
         )
     ) == handler
@@ -210,6 +210,7 @@ from unittest.mock import Mock, patch
 
 @patch("lazyscribe.artifacts.entry_points")
 def test_get_handler_type_error(mock_entry_points):
+    """Test raising an error when attempting to retrieve a custom handler through entry points."""
     mock_plugin = Mock()
     mock_plugin.name = "dummy"
 
@@ -220,6 +221,7 @@ def test_get_handler_type_error(mock_entry_points):
 
 @patch("lazyscribe.artifacts.entry_points")
 def test_get_handler_import_error(mock_entry_points):
+    """Test raising an import error when retrieving a custom handler through entry points."""
     mock_plugin_import = Mock()
     mock_plugin_import.name = "dummy"
     mock_plugin_import.load.side_effect = ImportError()

--- a/tests/test_linked.py
+++ b/tests/test_linked.py
@@ -39,7 +39,7 @@ def test_linked_list_conversion():
 
 
 def test_merge_no_overlap():
-    """Test merging two non-overlapping linked lists"""
+    """Test merging two non-overlapping linked lists."""
     first = LinkedList()
     first.append(1)
     first.append(3)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -71,9 +71,6 @@ def test_logging_experiment(project_kwargs):
         project["not a real experiment"]
 
 
-LOG = logging.getLogger(__name__)
-
-
 @time_machine.travel(
     datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
 )
@@ -88,6 +85,7 @@ LOG = logging.getLogger(__name__)
     ],
 )
 def test_logging(caplog, project_kwargs):
+    """Test logging to a project."""
     project = Project(**project_kwargs)
     today = datetime.now()
     caplog.set_level(logging.WARNING)
@@ -361,7 +359,7 @@ def test_save_project_artifact_failed_validation(mock_version, tmp_path):
     with pytest.raises(ArtifactLoadError):
         project2 = Project(project_location, mode="r")
         exp2 = project2["my-experiment"]
-        model_load = exp2.load_artifact(name="estimator")
+        exp2.load_artifact(name="estimator")
 
 
 def test_save_project_artifact_multi_experiment(tmp_path):

--- a/tutorials/prefect.py
+++ b/tutorials/prefect.py
@@ -33,9 +33,9 @@ def generate_data(
 
     Returns
     -------
-    np.ndarray
+    numpy.ndarray
         The feature space.
-    np.ndarray
+    numpy.ndarray
         The response vector.
     """
     return make_classification(n_samples=1000, n_features=10)
@@ -47,15 +47,15 @@ def fit_model(X: np.ndarray, y: np.ndarray) -> SVC:
 
     Parameters
     ----------
-    X : np.ndarray
+    X : numpy.ndarray
         The feature space.
-    y : np.ndarray
+    y : numpy.ndarray
         The response vector.
 
     Returns
     -------
-    SVC
-        Fitted ``SVC`` object.
+    sklearn.svm.SVC
+        Fitted object.
     """
     return SVC(kernel="linear").fit(X, y)
 
@@ -66,11 +66,11 @@ def score_model(estimator: SVC, X: np.ndarray, y: np.ndarray) -> float:
 
     Parameters
     ----------
-    estimator : SVC
+    estimator : sklearn.svm.SVC
         Fitted estimator.
-    X : np.ndarray
+    X : numpy.ndarray
         Feature space.
-    y : np.ndarray
+    y : numpy.ndarray
         Response vector.
 
     Returns


### PR DESCRIPTION
- Improve type annotations and documentation comments.
- Turn on stricter mypy and ruff checks.

See commit messages for details.

None of the Prefect code hasn't been touched, see #65.
Tended to _not_ add (runtime)  breaking changes.

The `lazyscribe.x.Y` notation is used for the https://github.com/lazyscribe/lazyscribe/issues/116#issuecomment-2711783475 issue.

~There are documentation placeholders, look for `TODO` substrings.~

Fixes: https://github.com/lazyscribe/lazyscribe/issues/114
Fixes: https://github.com/lazyscribe/lazyscribe/pull/91