### PR TITLE
fix: address handling of exact matches for the 'asof' match

### DIFF
--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -354,11 +354,17 @@ class Repository:
                     ) from None
             elif match == "asof":
                 try:
+                    if version < artifacts_matching_name[0].created_at:
+                        msg = (
+                            f"Version {version!s} predates the earliest version "
+                            f"{artifacts_matching_name[0].created_at!s}."
+                        )
+                        raise ValueError(msg) from None
                     artifact = next(
                         art
                         for idx, art in enumerate(artifacts_matching_name)
                         if (
-                            (version - art.created_at > timedelta(0))
+                            (version - art.created_at >= timedelta(0))
                             and (
                                 version - artifacts_matching_name[idx + 1].created_at
                                 < timedelta(0)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -420,12 +420,31 @@ def test_repository_asof_search(tmp_path):
 
     repository.save()
 
+    # Try loading with date before first artifact
+    with pytest.raises(ValueError) as exc_info:
+        repository.load_artifact(
+            name="my-dict", version=datetime(2024, 12, 31), match="asof"
+        )
+
+        assert str(exc_info.value) == (
+            "Version 2024-12-31T00:00:00 predates the earliest version 2025-01-01T00:00:00"
+        )
+
+    # Check loading an exact match
+    art = repository.load_artifact(
+        name="my-dict", version=datetime(2025, 1, 1), match="asof"
+    )
+
+    assert art == repository.load_artifact(name="my-dict", version=0)
+
+    # Check loading as of an intermediate date
     art = repository.load_artifact(
         name="my-dict", version=datetime(2025, 1, 15), match="asof"
     )
 
     assert art == repository.load_artifact(name="my-dict", version=datetime(2025, 1, 1))
 
+    # Check loading the latest
     art = repository.load_artifact(
         name="my-dict", version=datetime(2025, 3, 15), match="asof"
     )


### PR DESCRIPTION
## Description

In this PR, I've addressed a bug in the 1.0.0 handling of exact datetime matches when using `match="asof"`. Essentially, we needed `>=` instead of `>` in the main loop. I also added basic logic for handling (i.e. raising an exception) with an informative message when the user provides a date that predates the oldest artifact.