### PR TITLE
refactor: use `attrs.field` everywhere

### DIFF
--- a/lazyscribe/artifacts/joblib.py
+++ b/lazyscribe/artifacts/joblib.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, ClassVar
 
-from attrs import define
+from attrs import define, field
 from importlib_metadata import packages_distributions
 from importlib_metadata import version as importlib_version
 from slugify import slugify
@@ -47,9 +47,9 @@ class JoblibArtifact(Artifact):
     suffix: ClassVar[str] = "joblib"
     binary: ClassVar[bool] = True
     output_only: ClassVar[bool] = False
-    package: str
-    package_version: str
-    joblib_version: str
+    package: str = field()
+    package_version: str = field()
+    joblib_version: str = field()
 
     @classmethod
     def construct(

--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from json import dump, load
 from typing import Any, ClassVar
 
-from attrs import define
+from attrs import define, field
 from slugify import slugify
 
 from lazyscribe._utils import utcnow
@@ -28,7 +28,7 @@ class JSONArtifact(Artifact):
     suffix: ClassVar[str] = "json"
     binary: ClassVar[bool] = False
     output_only: ClassVar[bool] = False
-    python_version: str
+    python_version: str = field()
 
     @classmethod
     def construct(

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -53,7 +53,7 @@ class Experiment:
         experiment and the value is an :class:`Experiment` instance.
     """
 
-    name: str
+    name: str = field()
     project: Path = field(eq=False)
     dir: Path = field(eq=False)
     fs: AbstractFileSystem = field(eq=False)

--- a/lazyscribe/test.py
+++ b/lazyscribe/test.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Optional, Union
 
-from attrs import Factory, asdict, define, frozen
+from attrs import Factory, asdict, define, field, frozen
 
 from lazyscribe._utils import serializer
 
@@ -30,7 +30,7 @@ class Test:
     # Tell pytest it's not a Python test class
     __test__ = False
 
-    name: str
+    name: str = field()
     description: Optional[str] = Factory(lambda: None)
     metrics: dict = Factory(lambda: {})
     parameters: dict = Factory(lambda: {})


### PR DESCRIPTION
Use `attrs.field` everywhere.

Fixes: https://github.com/lazyscribe/lazyscribe/issues/109