### PR TITLE
feat: adding the ability for users to promote an artifact from an experiment to a repository

### DIFF
--- a/docs/how-to/version-artifacts.rst
+++ b/docs/how-to/version-artifacts.rst
@@ -1,0 +1,117 @@
+Version artifacts
+=================
+
+This guide will walk you through the process of using :py:class:`lazyscribe.Repository`
+to access and version artifacts across projects.
+
+    A :py:class:`lazyscribe.Repository` is an organized structure that stores and versions
+    your artifacts.
+
+Using a repository as a standalone structure
+--------------------------------------------
+
+If you have artifacts and/or objects that were generated outside of the ``lazyscribe`` ecosystem,
+you can still use them with the :py:class:`lazyscribe.Repository` structure. Similar to the guide
+on :doc:`saving artifacts with experiments <artifact>`, we will use
+:py:meth:`lazyscribe.Repository.log_artifact`:
+
+.. code-block:: python
+
+    from lazyscribe import Repository
+
+    repository = Repository("repository.json", mode="w")
+    repository.log_artifact(name="features", value=[0, 1, 2], handler="json", indent=4)
+
+    repository.save()
+
+After :py:meth:`lazyscribe.Repository.log_artifact`, the value ``[0, 1, 2]`` will be associated
+with the repository. However, it won't appear as a JSON file until you call
+:py:meth:`lazyscribe.Repository.save`. You can retrieve the artifact using
+:py:meth:`lazyscribe.Repository.load_artifact`:
+
+.. code-block:: python
+
+    from lazyscribe import Repository
+
+    repository = Repository("repository.json", mode="r")  # read-only mode
+    features = repository.load_artifact(name="features")
+
+So, what's the big deal? In the repository class, you can log artifacts with overlapping names. Each
+artifact is assigned an integer version number as well as a creation date, allowing you to time-travel
+between versions.
+
+.. code-block:: python
+
+    from lazyscribe import Repository
+
+    # append-only mode reads in the existing repository and allows for new artifacts
+    repository = Repository("repository.json", mode="a")
+    repository.log_artifact(name="features", value=[0, 1, 2, 3], handler="json", indent=4)
+
+    repository.save()
+
+Now we have two versions of the same ``features`` artifact. There are multiple ways to load a specific
+version of your artifact.
+
+.. code-block:: python
+
+    from lazyscribe import Repository
+
+    repository = Repository("repository.json", mode="r")
+
+    # Without any additional parameters, Repository will retrieve the most recent version
+    newest = repository.load_artifact("features")
+
+    # You can specify a specific integer version (0-indexed)
+    oldest = repository.load_artifact("features", version=0)
+
+    # Or the exact datetime
+    on_this_date = repository.load_artifact("features", version="YYYY-MM-DDTHH:MM:SS")
+
+    # To "time-travel", use `match="asof"` with a datetime version to get the most recent version
+    # as of the given date
+    as_of_this_date = repository.load_artifact("features", version="YYYY-MM-DDTHH:MM:SS", match="asof")
+
+Promote artifacts from experiments to the repository
+----------------------------------------------------
+
+Model experimentation is meant to be ephemeral. The Repository provides us with a structure to deploy
+and track versions of artifacts over time. So, how do these systems interact?
+
+We can use :py:meth:`lazyscribe.Experiment.promote_artifact` to associate an artifact with a repository.
+The notion is that you may want to deploy/version the artifacts from the most successful experiment in
+a project. Here's how you use it.
+
+First, let's create a project and log an experiment:
+
+.. code-block:: python
+
+    from lazyscribe import Project
+
+    project = Project("project.json")
+    with project.log("my-experiment") as exp:
+        exp.log_artifact(name="features", value=[0, 1, 2], handler="json", indent=4)
+
+    project.save()
+
+Now, let's reload that project and promote the artifact to the repository:
+
+.. code-block:: python
+
+    from lazyscribe import Project, Repository
+
+    project = Project("project.json", mode="r")
+    repository = Repository("repository.json")
+
+    project["my-experiment"].promote_artifact(repository, "features")
+
+If you are calling :py:meth:`lazyscribe.Experiment.promote_artifact` after re-loading a project,
+the method
+
+#. copies the artifact from the experiment filesystem location to the repository filesystem location, and
+#. calls :py:meth:`lazyscribe.Repository.save` to ensure ``repository.json`` is "in sync" with the filesystem.
+
+If you log the artifact to an experiment and call :py:meth:`lazyscribe.Experiment.promote_artifact` *before*
+calling :py:meth:`lazyscribe.Project.save`, it will behave exactly as if you called
+:py:meth:`lazyscribe.Repository.log_artifact` -- *you* will be responsible for calling
+:py:meth:`lazyscribe.Repository.save`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Contents
     how-to/tabular
     how-to/artifact
     how-to/custom-artifact
+    how-to/version-artifacts
     how-to/dependencies
     how-to/external-fs
     how-to/readonly

--- a/lazyscribe/exception.py
+++ b/lazyscribe/exception.py
@@ -9,6 +9,10 @@ class ReadOnlyError(LazyscribeError):
     """Raised when a project or repository is opened in read-only mode and write operations are tried."""
 
 
+class SaveError(LazyscribeError):
+    """Raised when a project or repository is unable to save objects to the filesystem."""
+
+
 class ArtifactError(LazyscribeError):
     """Base exception for artifact errors."""
 

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -479,10 +479,10 @@ class Experiment:
                     meta_ = repository.get_artifact_metadata(name)
                     if (
                         datetime.strptime(meta_["created_at"], "%Y-%m-%dT%H:%M:%S")
-                        > artifact.created_at
+                        >= artifact.created_at
                     ):
                         raise ArtifactLogError(
-                            f"Artifact `{name}` is older than the latest version available in the repository."
+                            f"Artifact `{name}` is not newer than the latest version available in the repository."
                         ) from None
                     new_handler = evolve(artifact, version=meta_["version"] + 1)
                 except ValueError:

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from attrs import Factory, asdict, define, field, fields, filters, frozen
+from attrs import Factory, asdict, define, evolve, field, fields, filters, frozen
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from slugify import slugify
@@ -19,6 +19,7 @@ from slugify import slugify
 from lazyscribe._utils import serializer, utcnow
 from lazyscribe.artifacts import Artifact, _get_handler
 from lazyscribe.exception import ArtifactLoadError, ArtifactLogError
+from lazyscribe.repository import Repository
 from lazyscribe.test import ReadOnlyTest, Test
 
 LOG = logging.getLogger(__name__)
@@ -437,6 +438,59 @@ class Experiment:
             },
             **{("metrics", key): value for key, value in d["metrics"].items()},
         }
+
+    def promote_artifact(self, repository: Repository, name: str):
+        """Associate an artifact with a :py:class:`lazyscribe.repository.Repository`.
+
+        The purpose of this method is to move an artifact from an *ephemeral*
+        experiment to the versioned repository.
+
+        If the artifact does not exist on disk yet, this function is simply a passthrough
+        to :py:meth:`lazyscribe.repository.Repository.log_artifact`. If the artifact does
+        exist on disk already, this function will copy the artifact from the experiment
+        directory to the repository, increment the version, and call
+        :py:meth:`lazyscribe.repository.Repository.save`.
+
+        Parameters
+        ----------
+        repository : Repository
+            The :py:class:`lazyscribe.repository.Repository` to promote the artifact to.
+        name : str
+            The artifact to promote.
+        """
+        for artifact in self.artifacts:
+            if artifact.name == name:
+                if artifact.dirty:
+                    LOG.debug(
+                        f"Artifact '{name}' does not exist on the filesystem yet, "
+                        "using `Repository.log_artifact`."
+                    )
+                    repository.log_artifact(
+                        name=name,
+                        value=artifact.value,
+                        handler=artifact.alias,
+                        fname=artifact.fname,
+                        **artifact.writer_kwargs,
+                    )
+                else:
+                    # The artifact is on disk, we will have to copy it over
+                    curr_path = self.path / artifact.fname
+                    new_path = repository.dir / artifact.name / artifact.fname
+                    LOG.info(f"Copying '{curr_path!s} to {new_path!s}")
+                    self.fs.copy(str(curr_path), str(new_path))
+
+                    existing_version = repository.get_artifact_metadata(name=name)[
+                        "version"
+                    ]
+                    new_handler = evolve(artifact, version=existing_version + 1)
+                    repository.artifacts.append(new_handler)
+                    LOG.info(
+                        "Calling `save` on the repository since the artifact exists on disk already."
+                    )
+                    repository.save()
+                break
+        else:
+            raise ArtifactLoadError(f"No artifact with name {name}")
 
     def __str__(self):
         """Shortened string representation."""

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -90,11 +90,6 @@ class Project:
         If the project is in read-only or append mode, existing experiments will
         be loaded in read-only mode. If opened in editable mode, existing experiments
         will be loaded in editable mode.
-
-        Raises
-        ------
-        SaveError
-            Raised when writing to the filesystem fails.
         """
         with self.fs.open(str(self.fpath), "r") as infile:
             data = json.load(infile)
@@ -172,6 +167,11 @@ class Project:
         """Save the project data.
 
         This includes saving any artifact data.
+
+        Raises
+        ------
+        SaveError
+            Raised when writing to the filesystem fails.
         """
         if self.mode == "r":
             raise ReadOnlyError("Project is in read-only mode.")
@@ -187,7 +187,7 @@ class Project:
                 json.dump(data, outfile, sort_keys=True, indent=4)
         except Exception as exc:
             raise SaveError(
-                "Unable to save the Project JSON file to %s", str(self.fpath)
+                f"Unable to save the Project JSON file to {self.fpath!s}"
             ) from exc
 
         mutable_: list[Experiment] = [

--- a/lazyscribe/project.py
+++ b/lazyscribe/project.py
@@ -187,7 +187,7 @@ class Project:
                 json.dump(data, outfile, sort_keys=True, indent=4)
         except Exception as exc:
             raise SaveError(
-                "Unable to save the Project JSON file to %s", str(self.path)
+                "Unable to save the Project JSON file to %s", str(self.fpath)
             ) from exc
 
         mutable_: list[Experiment] = [

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -276,6 +276,7 @@ class Repository:
             raise ReadOnlyError("Repository is in read-only mode.")
 
         data = list(self)
+        self.fs.makedirs(str(self.fpath.parent), exist_ok=True)
         with self.fs.open(str(self.fpath), "w") as outfile:
             json.dump(data, outfile, sort_keys=True, indent=4)
 

--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -287,7 +287,7 @@ class Repository:
                 json.dump(data, outfile, sort_keys=True, indent=4)
         except Exception as exc:
             raise SaveError(
-                "Unable to save the Repository JSON file to %s", str(self.fpath)
+                f"Unable to save the Repository JSON file to {self.fpath!s}"
             ) from exc
 
         for artifact in self.artifacts:

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,0 +1,166 @@
+"""Test promoting artifacts.
+
+These tests are in a separate module because it requires the interaction between
+projects and repositories.
+"""
+
+import json
+import sys
+import zoneinfo
+from datetime import datetime
+
+import time_machine
+
+from lazyscribe.project import Project
+from lazyscribe.repository import Repository
+
+
+def test_promote_artifact_dirty(tmp_path):
+    """Test promoting an artifact that hasn't been persisted to disk yet."""
+    location = tmp_path / "my-project"
+    project_location = location / "project.json"
+    repository_location = location / "repository.json"
+
+    repository = Repository(repository_location)
+    project = Project(project_location)
+
+    with project.log(name="My experiment") as exp:
+        with time_machine.travel(
+            datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")),
+            tick=False,
+        ):
+            exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
+        with time_machine.travel(
+            datetime(2025, 3, 1, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+        ):
+            exp.promote_artifact(repository, "features")
+
+    assert repository.get_artifact_metadata("features") == {
+        "name": "features",
+        "fname": "features-20250120132330.json",
+        "created_at": "2025-01-20T13:23:30",
+        "handler": "json",
+        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+        "version": 0,
+    }
+    assert repository.artifacts[0].value == project["my-experiment"].artifacts[0].value
+
+
+def test_promote_artifact_clean(tmp_path):
+    """Test promoting an artifact that exists on disk already."""
+    location = tmp_path / "my-project"
+    project_location = location / "project.json"
+    project = Project(project_location)
+
+    with (
+        project.log("My experiment") as exp,
+        time_machine.travel(
+            datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")),
+            tick=False,
+        ),
+    ):
+        exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
+
+    # Save the project
+    project.save()
+
+    repository_location = location / "repository.json"
+    repository = Repository(repository_location)
+
+    with time_machine.travel(
+        datetime(2025, 3, 1, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        reload_project = Project(project_location, mode="r")
+        reload_project["my-experiment"].promote_artifact(repository, "features")
+
+    assert (repository.dir / "features" / "features-20250120132330.json").is_file()
+    assert repository.get_artifact_metadata("features") == {
+        "name": "features",
+        "fname": "features-20250120132330.json",
+        "created_at": "2025-01-20T13:23:30",
+        "handler": "json",
+        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+        "version": 0,
+    }
+
+    with open(repository_location) as infile:
+        repo_data = json.load(infile)
+
+    assert repo_data == [
+        {
+            "name": "features",
+            "fname": "features-20250120132330.json",
+            "created_at": "2025-01-20T13:23:30",
+            "handler": "json",
+            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+            "version": 0,
+        }
+    ]
+
+
+def test_promote_artifact_new_version(tmp_path):
+    """Test promoting a new version of an existing artifact."""
+    location = tmp_path / "my-project"
+    repository_location = location / "repository.json"
+    repository = Repository(repository_location)
+
+    # Log version 0 of the artifact
+    with time_machine.travel(
+        datetime(2025, 1, 1, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+    ):
+        repository.log_artifact("features", [0, 1], handler="json")
+
+    # Save the repository
+    repository.save()
+
+    # Create a project and log a new version of the artifact
+    project_location = location / "project.json"
+    project = Project(project_location)
+    with (
+        project.log("My experiment") as exp,
+        time_machine.travel(
+            datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")),
+            tick=False,
+        ),
+    ):
+        exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
+
+    project.save()
+
+    # Reload the project and repository, promote the new object
+    reload_project = Project(project_location, mode="r")
+    reload_repository = Repository(repository_location, mode="a")
+
+    reload_project["my-experiment"].promote_artifact(reload_repository, "features")
+
+    assert (repository.dir / "features" / "features-20250120132330.json").is_file()
+    assert repository.get_artifact_metadata("features") == {
+        "name": "features",
+        "fname": "features-20250120132330.json",
+        "created_at": "2025-01-20T13:23:30",
+        "handler": "json",
+        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+        "version": 1,
+    }
+
+    with open(repository_location) as infile:
+        repo_data = json.load(infile)
+
+    assert repo_data == [
+        {
+            "name": "features",
+            "fname": "features-20250101000000.json",
+            "created_at": "2025-01-01T00:00:00",
+            "handler": "json",
+            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+            "version": 1,
+        },
+        {
+            "name": "features",
+            "fname": "features-20250120132330.json",
+            "created_at": "2025-01-20T13:23:30",
+            "handler": "json",
+            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
+            "version": 1,
+        },
+    ]

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -117,15 +117,15 @@ def test_promote_artifact_new_version(tmp_path):
     project_location = location / "project.json"
     project = Project(project_location)
     with (
-        project.log("My experiment") as exp,
         time_machine.travel(
             datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")),
             tick=False,
         ),
     ):
-        exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
+        with project.log("My experiment") as exp:
+            exp.log_artifact(name="features", value=[0, 1, 2], handler="json")
 
-    project.save()
+        project.save()
 
     # Reload the project and repository, promote the new object
     reload_project = Project(project_location, mode="r")
@@ -134,7 +134,7 @@ def test_promote_artifact_new_version(tmp_path):
     reload_project["my-experiment"].promote_artifact(reload_repository, "features")
 
     assert (repository.dir / "features" / "features-20250120132330.json").is_file()
-    assert repository.get_artifact_metadata("features") == {
+    assert reload_repository.get_artifact_metadata("features") == {
         "name": "features",
         "fname": "features-20250120132330.json",
         "created_at": "2025-01-20T13:23:30",
@@ -153,7 +153,7 @@ def test_promote_artifact_new_version(tmp_path):
             "created_at": "2025-01-01T00:00:00",
             "handler": "json",
             "python_version": ".".join(str(i) for i in sys.version_info[:2]),
-            "version": 1,
+            "version": 0,
         },
         {
             "name": "features",

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -9,10 +9,21 @@ import sys
 import zoneinfo
 from datetime import datetime
 
+import pytest
 import time_machine
 
+from lazyscribe.exception import ArtifactLoadError
 from lazyscribe.project import Project
 from lazyscribe.repository import Repository
+
+
+def test_promote_artifact_nonexistent():
+    """Test raising an error when a user promotes a non-existent artifact."""
+    project = Project()
+    repository = Repository()
+
+    with pytest.raises(ArtifactLoadError), project.log("My experiment") as exp:
+        exp.promote_artifact(repository, "fake-artifact")
 
 
 def test_promote_artifact_dirty(tmp_path):


### PR DESCRIPTION
## Overview

In this PR, I've added a method to the `Experiment` class that allows users to directly promote a logged artifact to a `Repository`. There are two main branches of logic here:

1. **The Artifact is `dirty`**: in this case, the artifact will need to be saved to the file system regardless. We can just append the artifact handler to the list in `Repository`.
2. **The Artifact is not `dirty`**: here, the artifact exists on the file system and does not need to be overwritten. So, we can append the artifact handler and copy the file. Crucially, we need to call `Repository.save`; without this call, the user may end up with an artifact file in their directory structure that is not associated with anything in the `repository.json` file.

cc @Dike-LAN @valdezt 