### PR TITLE
fix(repository): `repository.Repository`: fix `mode` handling

### DIFF
--- a/lazyscribe/repository.py
+++ b/lazyscribe/repository.py
@@ -34,11 +34,10 @@ class Repository:
     mode : {"r", "a", "w", "w+"}, optional (default "w")
         The mode for opening the repository.
 
-        * ``r``: Repository loaded as read-only: no new artifacts can be logged.
-        * ``a``: All existing artifacts will be loaded as
-          read-only and new artifacts can be added.
+        * ``r``: No new artifacts can be logged.
+        * ``a``: The same as ``w+`` (deprecated).
         * ``w``: No existing artifacts will be loaded.
-        * ``w+``: All artifacts will be loaded in editable mode.
+        * ``w+``: All artifacts will be loaded.
 
     Attributes
     ----------
@@ -49,7 +48,9 @@ class Repository:
     def __init__(
         self,
         fpath: str | Path = "repository.json",
-        mode: Literal["r", "a", "w", "w+"] = "w",
+        mode: Literal[
+            "r", "a", "w", "w+"
+        ] = "w",  # TODO: remove `mode="a"` in version 2.0
         **storage_options,
     ):
         """Init method."""
@@ -63,14 +64,20 @@ class Repository:
         self.dir = self.fpath.parent
         self.storage_options = storage_options
 
-        # If in ``r``, ``a``, or ``w+`` mode, read in the existing repository.
         self.artifacts: list[Artifact] = []
         self.fs = fsspec.filesystem(self.protocol, **storage_options)
 
         if mode not in ("r", "a", "w", "w+"):
             raise ValueError("Please provide a valid ``mode`` value.")
+        if mode == "a":
+            warnings.warn(
+                '`mode="a"` is deprecated and will be removed from `lazyscribe.repository.Repository` in version 2.0',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            mode = "w+"
         self.mode = mode
-        if mode in ("r", "a", "w+") and self.fs.isfile(str(self.fpath)):
+        if mode in ("r", "w+") and self.fs.isfile(str(self.fpath)):
             self.load()
 
     def load(self):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -105,7 +105,7 @@ def test_save_repository_multi(tmp_path):
     assert repository_location.is_file()
 
     # Read in the repository again and log a separate artifact
-    repository_read = Repository(repository_location, mode="a")
+    repository_read = Repository(repository_location, mode="w+")
     repository_read.log_artifact("my-dict-2", {"b": 2}, handler="json")
 
     assert repository_read["my-dict"].dirty is False
@@ -470,3 +470,17 @@ def test_retrieve_artifact_meta():
         "python_version": ".".join(str(i) for i in sys.version_info[:2]),
         "version": 0,
     }
+
+
+def test_repository_append_mode_deprecation(tmp_path):
+    """Test reading a repository in append mode."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        repository = Repository(fpath=DATA_DIR / "repository.json", mode="a")
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert (
+            '`mode="a"` is deprecated and will be removed from `lazyscribe.repository.Repository` in version 2.0'
+            in str(w[-1].message)
+        )
+    assert repository.mode == "w+"


### PR DESCRIPTION
- There is no "a read-only artifact".
- `mode="a"` is not relevant to the repository.

Closes: https://github.com/lazyscribe/lazyscribe/issues/104