### PR TITLE
refactor: widening artifact metadata and consolidating environment reconciliation logic

### DIFF
--- a/lazyscribe/_utils.py
+++ b/lazyscribe/_utils.py
@@ -1,5 +1,7 @@
 """Util methods."""
 
+import inspect
+import json
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any
@@ -7,6 +9,7 @@ from typing import Any
 from attrs import Attribute, asdict, fields, filters
 
 from lazyscribe.artifacts.base import Artifact
+from lazyscribe.exception import ArtifactLoadError
 
 
 def serializer(inst: type, field: "Attribute[Any]", value: Any) -> Any:
@@ -73,3 +76,51 @@ def utcnow() -> datetime:
         Now in UTC, without timezone info.
     """
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def validate_artifact_environment(artifact: Artifact) -> None:
+    """Validate the artifact handler environment.
+
+    Parameters
+    ----------
+    artifact : Artifact
+        An artifact handler instantiated from project and/or repository metadata.
+
+    Raises
+    ------
+    lazyscribe.exception.ArtifactLoadError
+        Raised if the runtime environment does not match artifact metadata.
+    """
+    # Construct the handler with relevant parameters.
+    artifact_attrs: dict[str, Any] = {
+        x: y
+        for x, y in inspect.getmembers(artifact)
+        if not x.startswith("_") and not inspect.ismethod(y)
+    }
+    # Exclude parameters that don't define equality
+    exclude_names: list[str] = [
+        attr.name for attr in fields(type(artifact)) if not attr.eq
+    ]
+    construct_params: list[str] = [
+        param_name
+        for param_name, param in inspect.signature(
+            artifact.construct
+        ).parameters.items()
+        if param_name not in exclude_names or param.default == param.empty
+    ]
+    artifact_attrs = {
+        key: value for key, value in artifact_attrs.items() if key in construct_params
+    }
+
+    curr_handler = type(artifact).construct(**artifact_attrs, dirty=False)
+    # Validate the handler
+    if curr_handler != artifact:
+        field_filters = filters.exclude(
+            *[attr for attr in fields(type(artifact)) if not attr.eq]
+        )
+        raise ArtifactLoadError(
+            "Runtime environments do not match. Artifact parameters:\n\n"
+            f"{json.dumps(asdict(artifact, filter=field_filters))}"
+            "\n\nCurrent parameters:\n\n"
+            f"{json.dumps(asdict(curr_handler, filter=field_filters))}"
+        )

--- a/lazyscribe/artifacts/__init__.py
+++ b/lazyscribe/artifacts/__init__.py
@@ -1,9 +1,6 @@
 """Import the handlers."""
 
-try:
-    from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points  # type: ignore
+from importlib.metadata import entry_points
 
 from lazyscribe.artifacts.base import Artifact
 

--- a/lazyscribe/experiment.py
+++ b/lazyscribe/experiment.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import getpass
-import inspect
-import json
 import logging
 import os
 import warnings
@@ -16,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 from attrs import (
-    Attribute,
     Factory,
     asdict,
     define,
@@ -30,7 +27,7 @@ from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from slugify import slugify
 
-from lazyscribe._utils import serializer, utcnow
+from lazyscribe._utils import serializer, utcnow, validate_artifact_environment
 from lazyscribe.artifacts import _get_handler
 from lazyscribe.artifacts.base import Artifact
 from lazyscribe.exception import ArtifactLoadError, ArtifactLogError, SaveError
@@ -327,45 +324,13 @@ class Experiment:
         """
         for artifact in self.artifacts:
             if artifact.name == name:
-                # Construct the handler with relevant parameters.
-                artifact_attrs: dict[str, Any] = {
-                    x: y
-                    for x, y in inspect.getmembers(artifact)
-                    if not x.startswith("_") and not inspect.ismethod(y)
-                }
-                # Exclude parameters that don't define equality
-                exclude_fields: list[Attribute] = [
-                    attr for attr in artifact.__attrs_attrs__ if not attr.eq
-                ]
-                construct_params: list[str] = [
-                    param_name
-                    for param_name, param in inspect.signature(
-                        artifact.construct
-                    ).parameters.items()
-                    if param_name not in [attr.name for attr in exclude_fields]
-                    or param.default == param.empty
-                ]
-                artifact_attrs = {
-                    key: value
-                    for key, value in artifact_attrs.items()
-                    if key in construct_params
-                }
-
-                curr_handler = type(artifact).construct(**artifact_attrs, dirty=False)
-
                 # Validate the handler
-                if validate and curr_handler != artifact:
-                    field_filters = filters.exclude(*exclude_fields)
-                    raise ArtifactLoadError(
-                        "Runtime environments do not match. Artifact parameters:\n\n"
-                        f"{json.dumps(asdict(artifact, filter=field_filters))}"
-                        "\n\nCurrent parameters:\n\n"
-                        f"{json.dumps(asdict(curr_handler, filter=field_filters))}"
-                    )
+                if validate:
+                    validate_artifact_environment(artifact)
                 # Read in the artifact
-                mode = "rb" if curr_handler.binary else "r"
+                mode = "rb" if artifact.binary else "r"
                 with self.fs.open(str(self.path / artifact.fname), mode) as buf:
-                    out = curr_handler.read(buf, **kwargs)
+                    out = artifact.read(buf, **kwargs)
                 if artifact.output_only:
                     warnings.warn(
                         f"Artifact '{name}' is not the original Python Object",


### PR DESCRIPTION
In this PR, I've made two changes to our artifact loading:

* Any field with `eq=False` will be excluded from environment validation, and
* Consolidated validation logic in a helper function.
