### PR TITLE
chore: get rid of `typing.Union`

### DIFF
--- a/lazyscribe/prefect/experiment.py
+++ b/lazyscribe/prefect/experiment.py
@@ -4,7 +4,7 @@ import getpass
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import prefect
 from prefect import Flow, Task, task
@@ -16,7 +16,7 @@ from lazyscribe.test import Test
 
 
 @task(name="Log experiment metric")
-def log_experiment_metric(experiment: Experiment, name: str, value: Union[float, int]):
+def log_experiment_metric(experiment: Experiment, name: str, value: float | int):
     """Log a metric.
 
     Parameters
@@ -193,7 +193,7 @@ class LazyExperiment(Task):
 
         return Experiment(name=name, project=project, author=author)
 
-    def log_metric(self, name: str, value: Union[float, int]):
+    def log_metric(self, name: str, value: float | int):
         """Add a ``log_metric`` task.
 
         Parameters

--- a/lazyscribe/prefect/project.py
+++ b/lazyscribe/prefect/project.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
 from urllib.parse import urlparse
 
 import prefect
@@ -229,7 +229,7 @@ class LazyProject(Task):
     def log(
         self,
         name: str,
-        project: Optional[Union[str, Path, Parameter]] = None,
+        project: Optional[str | Path | Parameter] = None,
         author: Optional[str] = None,
         flow: Optional[Flow] = None,
     ) -> Iterator[Task]:

--- a/lazyscribe/prefect/test.py
+++ b/lazyscribe/prefect/test.py
@@ -1,6 +1,6 @@
 """Prefect test tasks."""
 
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from prefect import Task, task
 from prefect.utilities.tasks import defaults_from_attrs
@@ -9,7 +9,7 @@ from lazyscribe.test import Test
 
 
 @task(name="Log test metric")
-def log_test_metric(test: Test, name: str, value: Union[float, int]):
+def log_test_metric(test: Test, name: str, value: float | int):
     """Log a non-global metric to a test.
 
     Parameters
@@ -82,7 +82,7 @@ class LazyTest(Task):
 
         return Test(name=name, description=description)
 
-    def log_metric(self, name: str, value: Union[float, int]):
+    def log_metric(self, name: str, value: float | int):
         """Add a ``log_metric`` task.
 
         Parameters


### PR DESCRIPTION
As we use Python 3.10 since #153 .