### PR TITLE
feat: removing the python version check from the JSON handler

### DIFF
--- a/lazyscribe/artifacts/json.py
+++ b/lazyscribe/artifacts/json.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime
 from io import IOBase
 from json import dump, load
 from typing import Any, ClassVar
 
-from attrs import define, field
+from attrs import define
 from slugify import slugify
 
 from lazyscribe._utils import utcnow
@@ -43,7 +42,6 @@ class JSONArtifact(Artifact):
     suffix: ClassVar[str] = "json"
     binary: ClassVar[bool] = False
     output_only: ClassVar[bool] = False
-    python_version: str = field()
 
     @classmethod
     def construct(
@@ -80,17 +78,12 @@ class JSONArtifact(Artifact):
             Whether or not this artifact should be saved when :py:meth:`lazyscribe.project.Project.save`
             or :py:meth:`lazyscribe.repository.Repository.save` is called. This decision is based
             on whether the artifact is new or has been updated.
-        python_version : str, optional
-            Minor Python version (e.g. ``"3.10"``).
 
         Returns
         -------
         JSONArtifact
             The artifact.
         """
-        python_version = kwargs.get("python_version") or ".".join(
-            str(i) for i in sys.version_info[:2]
-        )
         created_at = created_at or utcnow()
         return cls(
             name=name,
@@ -101,7 +94,6 @@ class JSONArtifact(Artifact):
             writer_kwargs=writer_kwargs or {},
             version=version,
             dirty=dirty,
-            python_version=python_version,
         )
 
     @classmethod

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,6 +1,5 @@
 """Test the experiment dataclass."""
 
-import sys
 import warnings
 import zoneinfo
 from datetime import datetime
@@ -162,7 +161,6 @@ def test_experiment_artifact_logging_basic():
                 "fname": f"features-{today.strftime('%Y%m%d%H%M%S')}.json",
                 "handler": "json",
                 "created_at": today.strftime("%Y-%m-%dT%H:%M:%S"),
-                "python_version": ".".join(str(i) for i in sys.version_info[:2]),
                 "version": 0,
             }
         ],

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -5,7 +5,6 @@ projects and repositories.
 """
 
 import json
-import sys
 import zoneinfo
 from datetime import datetime
 
@@ -115,7 +114,6 @@ def test_promote_artifact_dirty(tmp_path):
         "fname": "features-20250120132330.json",
         "created_at": "2025-01-20T13:23:30",
         "handler": "json",
-        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
         "version": 0,
     }
     assert repository.artifacts[0].value == project["my-experiment"].artifacts[0].value
@@ -154,7 +152,6 @@ def test_promote_artifact_clean(tmp_path):
         "fname": "features-20250120132330.json",
         "created_at": "2025-01-20T13:23:30",
         "handler": "json",
-        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
         "version": 0,
     }
 
@@ -167,7 +164,6 @@ def test_promote_artifact_clean(tmp_path):
             "fname": "features-20250120132330.json",
             "created_at": "2025-01-20T13:23:30",
             "handler": "json",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         }
     ]
@@ -214,7 +210,6 @@ def test_promote_artifact_new_version(tmp_path):
         "fname": "features-20250120132330.json",
         "created_at": "2025-01-20T13:23:30",
         "handler": "json",
-        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
         "version": 1,
     }
 
@@ -227,7 +222,6 @@ def test_promote_artifact_new_version(tmp_path):
             "fname": "features-20250101000000.json",
             "created_at": "2025-01-01T00:00:00",
             "handler": "json",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
         {
@@ -235,7 +229,6 @@ def test_promote_artifact_new_version(tmp_path):
             "fname": "features-20250120132330.json",
             "created_at": "2025-01-20T13:23:30",
             "handler": "json",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 1,
         },
     ]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -3,7 +3,6 @@
 import difflib
 import json
 import logging
-import sys
 import warnings
 import zoneinfo
 from datetime import datetime
@@ -82,7 +81,6 @@ def test_save_repository(tmp_path):
             "fname": expected_fname,
             "handler": "json",
             "name": "my-dict",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
     ]
@@ -171,7 +169,6 @@ def test_save_repository_multi(tmp_path):
             "fname": "my-dict-20250120132330.json",
             "handler": "json",
             "name": "my-dict",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
         {
@@ -179,7 +176,6 @@ def test_save_repository_multi(tmp_path):
             "fname": "my-dict-2-20250120132330.json",
             "handler": "json",
             "name": "my-dict-2",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
     ]
@@ -230,7 +226,6 @@ def test_save_repository_multiple_artifact(tmp_path):
             "fname": expected_my_dict_fname0,
             "handler": "json",
             "name": "my-dict",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
         {
@@ -238,7 +233,6 @@ def test_save_repository_multiple_artifact(tmp_path):
             "fname": expected_my_dict2_fname,
             "handler": "json",
             "name": "my-dict2",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 0,
         },
         {
@@ -246,7 +240,6 @@ def test_save_repository_multiple_artifact(tmp_path):
             "fname": expected_my_dict_fname1,
             "handler": "json",
             "name": "my-dict",
-            "python_version": ".".join(str(i) for i in sys.version_info[:2]),
             "version": 1,
         },
     ]
@@ -518,7 +511,6 @@ def test_retrieve_artifact_meta():
         "fname": "my-dict-20250120132330.json",
         "handler": "json",
         "name": "my-dict",
-        "python_version": ".".join(str(i) for i in sys.version_info[:2]),
         "version": 0,
     }
 


### PR DESCRIPTION
In this PR, I've removed our Python version restriction on JSON artifacts. I think that we should only restrict python version compatibility based on whether the file format can be read in multiple python versions.

I have tested that this is not breaking using the following procedure. In 3.10, using the `develop` branch, I created a repository with a JSON artifact

```console
In [1]: from lazyscribe import Repository
In [2]: repo = Repository("repository.json")
In [3]: repo.log_artifact(name="test-artifact", value=[{"entry": 0}], handler="json", indent=4)
In [4]: repo.save()
```

with the following repository JSON file:

```json
[
    {
        "created_at": "2025-12-03T17:07:46",
        "fname": "test-artifact-20251203170746.json",
        "handler": "json",
        "name": "test-artifact",
        "python_version": "3.10",
        "version": 0
    }
]
```

then, on this branch, using

```bash
uvx --python 3.12 --with . --with ipython ipython
```

I ran

```console
In [1]: from lazyscribe import Repository
In [2]: repo = Repository("repository.json", mode="r")
In [3]: out = repo.load_artifact(name="test-artifact")
In [4]: out = repo.load_artifact(name="test-artifact")
In [5]: out
Out[5]: [{'entry': 0}]
```